### PR TITLE
Changelog entry per merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/)
 
+## [Unreleased]
+### Added
+- mobile_security_misconfiguration.ssl_certificate_pinning
+- mobile_security_misconfiguration.ssl_certificate_pinning.absent
+- mobile_security_misconfiguration.ssl_certificate_pinning.defeatable
+- insecure_direct_object_references_idor.visible_detailed_error_page.detailed_server_configuration
+- insecure_direct_object_references_idor.visible_detailed_error_page.descriptive_stack_trace
+- unvalidated_redirects_and_forwards.open_redirect.get_based
+
+### Removed
+- insecure_data_transport
+- insecure_data_transport.ssl_certificate_pinning
+- insecure_data_transport.ssl_certificate_pinning.absent
+- insecure_data_transport.ssl_certificate_pinning.defeatable
+- unvalidated_redirects_and_forwards.open_redirect.get_based_all_users
+- unvalidated_redirects_and_forwards.open_redirect.get_based_authenticated
+- unvalidated_redirects_and_forwards.open_redirect.get_based_unauthenticated
+
+### Changed
+- server_security_misconfiguration.mail_server_misconfiguration.missing_dmarc name changed from 'Missing DMARC' to 'Missing DKIM/DMARC'
+
 ## [v1.1.0](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.0...v1.1) - 2017-04-13
 ### Added
 - directory_listing_enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
-- mobile_security_misconfiguration.ssl_certificate_pinning
-- mobile_security_misconfiguration.ssl_certificate_pinning.absent
-- mobile_security_misconfiguration.ssl_certificate_pinning.defeatable
 - insecure_direct_object_references_idor.visible_detailed_error_page.detailed_server_configuration
 - insecure_direct_object_references_idor.visible_detailed_error_page.descriptive_stack_trace
 - unvalidated_redirects_and_forwards.open_redirect.get_based
 
 ### Removed
 - insecure_data_transport
-- insecure_data_transport.ssl_certificate_pinning
-- insecure_data_transport.ssl_certificate_pinning.absent
-- insecure_data_transport.ssl_certificate_pinning.defeatable
 - unvalidated_redirects_and_forwards.open_redirect.get_based_all_users
 - unvalidated_redirects_and_forwards.open_redirect.get_based_authenticated
 - unvalidated_redirects_and_forwards.open_redirect.get_based_unauthenticated
 
 ### Changed
 - server_security_misconfiguration.mail_server_misconfiguration.missing_dmarc name changed from 'Missing DMARC' to 'Missing DKIM/DMARC'
+- insecure_data_transport.ssl_certificate_pinning moved via category change to mobile_security_misconfiguration.ssl_certificate_pinning
+- insecure_data_transport.ssl_certificate_pinning.absent moved via category change to mobile_security_misconfiguration.ssl_certificate_pinning.absent
+- insecure_data_transport.ssl_certificate_pinning.defeatable moved via category change to mobile_security_misconfiguration.ssl_certificate_pinning.defeatable
 
 ## [v1.1.0](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.0...v1.1) - 2017-04-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - sensitive_data_exposure.visible_detailed_error_page.full_path_disclosure
 - sensitive_data_exposure.internal_ip_disclosure
 - server_security_misconfiguration.cookie_scoped_to_parent_domain
+- client_side_injection.binary_planting
+- client_side_injection.binary_planting.privilege_escalation
+- client_side_injection.binary_planting.no_privilege_escalation
 
 ### Removed
 - insecure_data_transport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - unvalidated_redirects_and_forwards.open_redirect.get_based
 - sensitive_data_exposure.visible_detailed_error_page.full_path_disclosure
 - sensitive_data_exposure.internal_ip_disclosure
+- server_security_misconfiguration.cookie_scoped_to_parent_domain
 
 ### Removed
 - insecure_data_transport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - insecure_direct_object_references_idor.visible_detailed_error_page.detailed_server_configuration
 - insecure_direct_object_references_idor.visible_detailed_error_page.descriptive_stack_trace
 - unvalidated_redirects_and_forwards.open_redirect.get_based
+- sensitive_data_exposure.visible_detailed_error_page.full_path_disclosure
+- sensitive_data_exposure.internal_ip_disclosure
 
 ### Removed
 - insecure_data_transport

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
-- insecure_direct_object_references_idor.visible_detailed_error_page.detailed_server_configuration
-- insecure_direct_object_references_idor.visible_detailed_error_page.descriptive_stack_trace
-- unvalidated_redirects_and_forwards.open_redirect.get_based
-- sensitive_data_exposure.visible_detailed_error_page.full_path_disclosure
 - sensitive_data_exposure.internal_ip_disclosure
+- sensitive_data_exposure.visible_detailed_error_page.full_path_disclosure
+- sensitive_data_exposure.visible_detailed_error_page.descriptive_stack_trace
+- sensitive_data_exposure.visible_detailed_error_page.detailed_server_configuration
+- unvalidated_redirects_and_forwards.open_redirect.get_based
 - server_security_misconfiguration.cookie_scoped_to_parent_domain
 - client_side_injection.binary_planting
 - client_side_injection.binary_planting.privilege_escalation
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - unvalidated_redirects_and_forwards.open_redirect.get_based_unauthenticated
 
 ### Changed
+- sensitive_data_exposure.visible_detailed_error_page name changed from 'Visible Detailed Error Page' to 'Visible Detailed Error/Debug Page'
 - server_security_misconfiguration.mail_server_misconfiguration.missing_dmarc name changed from 'Missing DMARC' to 'Missing DKIM/DMARC'
 - insecure_data_transport.ssl_certificate_pinning moved via category change to mobile_security_misconfiguration.ssl_certificate_pinning
 - insecure_data_transport.ssl_certificate_pinning.absent moved via category change to mobile_security_misconfiguration.ssl_certificate_pinning.absent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,14 @@ you may open a pull request directly for these examples. Prior to opening a pull
 ### CHANGELOG Entry
 When a PR is open, to add an entry to `CHANGELOG.md` under the `[Unreleased]` header, following the format from [Keep a CHANGELOG](http://keepachangelog.com/en/0.3.0/) and our previous releases.
 
-To detail, an entry can go in one of three headers, `Added`, `Removed`, or `Changed`. For `Added` or `Removed` categories add a bullet (`-`) then state the `ID` of the entry that was either added or removed.  With `Changed`, use the format of:
+To detail, an entry can go in one of three headers, `Added`, `Removed`, or `Changed`. For `Added` or `Removed` categories add a bullet (`-`) then state the `ID` of the entry that was either added or removed.  With `Changed`, we handle attribute or parent changes.
+
+If a data attribute (name or priority) changes, use the format of:
 ```
 - {ID} {attribute} changed from {old value} to {new value}
+```
+
+Yet if the parent changes, the format below should be used:
+```
+- {old ID} moved via {type} change to {new ID}
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,11 @@ you may open a pull request directly for these examples. Prior to opening a pull
  1. Install `jsonschema` via pip with `pip install jsonschema`
   - If you don't have pip, you can install it like so: `easy_install pip`
  2. Run `validate-vrt.py`
+
+### CHANGELOG Entry
+When a PR is open, to add an entry to `CHANGELOG.md` under the `[Unreleased]` header, following the format from [Keep a CHANGELOG](http://keepachangelog.com/en/0.3.0/) and our previous releases.
+
+To detail, an entry can go in one of three headers, `Added`, `Removed`, or `Changed`. For `Added` or `Removed` categories add a bullet (`-`) then state the `ID` of the entry that was either added or removed.  With `Changed`, use the format of:
+```
+- {ID} {attribute} changed from {old value} to {new value}
+```

--- a/validate-vrt.py
+++ b/validate-vrt.py
@@ -2,6 +2,7 @@
 import json
 import jsonschema
 import sys
+import subprocess
 from jsonschema import Draft4Validator
 from jsonschema.exceptions import best_match
 
@@ -16,6 +17,16 @@ def get_json(filename):
         print('Error: Not a valid JSON file:', filename)
         sys.exit(e)
 
+def is_changelog_updated():
+    '''
+    Checks if CHANGELOG.md is being updated with the current commit
+    and prompts the user if it isn't
+    '''
+    p = subprocess.Popen("git diff HEAD --stat --staged CHANGELOG.md | wc -l", shell=True, stdout=subprocess.PIPE)
+    out, err = p.communicate()
+    if not int(out):
+        print('\n########## Make sure to update CHANGELOG.md! ##########\n')
+
 def main():
     vrt_schema = get_json("vrt.schema.json")
     vrt_json = get_json("vulnerability-rating-taxonomy.json")
@@ -29,6 +40,7 @@ def main():
             sys.exit(1)
         else:
             print('JSON validation success!')
+            is_changelog_updated()
 
 if __name__ == '__main__':
     main()

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1059,20 +1059,8 @@
           "type": "subcategory",
           "children": [
             {
-              "id": "get_based_all_users",
-              "name": "GET-Based (All Users)",
-              "type": "variant",
-              "priority": 3
-            },
-            {
-              "id": "get_based_authenticated",
-              "name": "GET-Based (Authenticated)",
-              "type": "variant",
-              "priority": 4
-            },
-            {
-              "id": "get_based_unauthenticated",
-              "name": "GET-Based (Unauthenticated)",
+              "id": "get_based",
+              "name": "GET-Based",
               "type": "variant",
               "priority": 4
             },


### PR DESCRIPTION
I am not a huge fan of the add/remove entries for a node that is being moved and keeping the subcategory/variants but unsure how else to do it. I tried doing it within `Changed`: 
```
- mobile_security_misconfiguration.ssl_certificate_pinning change category from insecure_data_transport to mobile_security_misconfiguration
```
but that seems a bit awkward as well. Open to other ideas?