### PR TITLE
Add JSON Hijacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - client_side_injection.binary_planting.no_privilege_escalation
 - sensitive_data_exposure.token_leakage_via_referer.trusted_3rd_party
 - sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party
+- sensitive_data_exposure.json_hijacking
 
 ### Removed
 - insecure_data_transport

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -822,6 +822,12 @@
           "name": "Non-Sensitive Token in URL",
           "type": "subcategory",
           "priority": 5
+        },
+        {
+          "id": "json_hijacking",
+          "name": "JSON Hijacking",
+          "type": "subcategory",
+          "priority": 5
         }
       ]
     },


### PR DESCRIPTION
This resolves #22. As discussed internally we are addressing JSON Hijacking as a separate P5 entry due to a very low probability of exploitation on modern browsers. Classifying this type of issues as P5 provides multiple benefits to a crowd sourced taxonomy. As a general rule priority can be upgraded on a case by case basis leaving the door open for valid findings.