### PR TITLE
Fix Sensitive/Session Token in URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - sensitive_data_exposure.token_leakage_via_referer.over_https
 - sensitive_data_exposure.mixed_content.sensitive_data_disclosure
 - sensitive_data_exposure.mixed_content.requires_being_a_man_in_the_middle
+- broken_authentication_and_session_management.session_token_in_url
+- broken_authentication_and_session_management.session_token_in_url.over_http
+- broken_authentication_and_session_management.session_token_in_url.over_https
 
 ### Changed
 - sensitive_data_exposure.visible_detailed_error_page name changed from 'Visible Detailed Error Page' to 'Visible Detailed Error/Debug Page'

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -7,5 +7,14 @@
   },
   "unvalidated_redirects_and_forwards.open_redirect.get_based_unauthenticated": {
     "1.2": "unvalidated_redirects_and_forwards.open_redirect.get_based"
+  },
+  "broken_authentication_and_session_management.session_token_in_url.over_https": {
+    "1.2": "sensitive_data_exposure.sensitive_token_in_url"
+  },
+  "broken_authentication_and_session_management.session_token_in_url.over_http": {
+    "1.2": "sensitive_data_exposure.sensitive_token_in_url"
+  },
+  "broken_authentication_and_session_management.session_token_in_url": {
+    "1.2": "sensitive_data_exposure.sensitive_token_in_url"
   }
 }

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -623,25 +623,6 @@
           ]
         },
         {
-          "id": "session_token_in_url",
-          "name": "Session Token in URL",
-          "type": "subcategory",
-          "children": [
-            {
-              "id": "over_http",
-              "name": "Over HTTP",
-              "type": "variant",
-              "priority": 4
-            },
-            {
-              "id": "over_https",
-              "name": "Over HTTPS",
-              "type": "variant",
-              "priority": 5
-            }
-          ]
-        },
-        {
           "id": "concurrent_logins",
           "name": "Concurrent Logins",
           "type": "subcategory",
@@ -774,6 +755,12 @@
           "priority": 4
         },
         {
+          "id": "non_sensitive_token_in_url",
+          "name": "Non-Sensitive Token in URL",
+          "type": "subcategory",
+          "priority": 5
+        },
+        {
           "id": "weak_password_reset_implementation",
           "name": "Weak Password Reset Implementation",
           "type": "subcategory",
@@ -814,12 +801,6 @@
         {
           "id": "internal_ip_disclosure",
           "name": "Internal IP Disclosure",
-          "type": "subcategory",
-          "priority": 5
-        },
-        {
-          "id": "non_sensitive_token_in_url",
-          "name": "Non-Sensitive Token in URL",
           "type": "subcategory",
           "priority": 5
         }


### PR DESCRIPTION
As discussed internally today this resolves #38. We are removing the entire `Broken Authentication and Session Management->Session Token in URL` subcategory and leaving `Sensitive Data Exposure->Sensitive Token in URL (P4)`. We will no longer distinguish session from sensitive tokens in URL nor will we differentiate HTTP from HTTPS in this particular case.

I am also moving the existing `Sensitive Data Exposure->Non-Sensitive Token in URL (P5)` directly below its sensitive counterpart.