### PR TITLE
 add-depprecated-mapping-validation-to-ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM python:2.7
 ADD validate-vrt.py /
+ADD validate-deprecated-mapping.py /
 ADD vrt.schema.json /
 ADD vulnerability-rating-taxonomy.json /
+ADD deprecated-node-mapping.json  /
 
 RUN pip install jsonschema
+RUN pip install GitPython
 
-CMD [ "python", "./validate-vrt.py" ]
+CMD [ "python", "./validate-vrt.py", "&&", "python", "./validate-deprecated-mapping.py"]


### PR DESCRIPTION
solves this issue: https://github.com/bugcrowd/vulnerability-rating-taxonomy/issues/44
another good exercise would be to validate that all nodes from every version map to something in the current version, since this can easily cause a bug if unaccounted for.