### PR TITLE
Add removed top-level categories to deprecated node mapping

### DIFF
--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -1,4 +1,10 @@
 {
+  "poor_physical_security": {
+    "1.1": "other"
+  },
+  "social_engineering": {
+    "1.1": "other"
+  },
   "unvalidated_redirects_and_forwards.open_redirect.get_based_all_users": {
     "1.2": "unvalidated_redirects_and_forwards.open_redirect.get_based"
   },
@@ -16,5 +22,17 @@
   },
   "broken_authentication_and_session_management.session_token_in_url": {
     "1.2": "sensitive_data_exposure.sensitive_token_in_url"
+  },
+  "insecure_data_transport": {
+    "1.2": "mobile_security_misconfiguration"
+  },
+  "insecure_data_transport.ssl_certificate_pinning": {
+    "1.2": "mobile_security_misconfiguration.ssl_certificate_pinning"
+  },
+  "insecure_data_transport.ssl_certificate_pinning.absent": {
+    "1.2": "mobile_security_misconfiguration.ssl_certificate_pinning.absent"
+  },
+  "insecure_data_transport.ssl_certificate_pinning.defeatable": {
+    "1.2": "mobile_security_misconfiguration.ssl_certificate_pinning.defeatable"
   }
 }


### PR DESCRIPTION
This pr https://github.com/bugcrowd/vulnerability-rating-taxonomy/pull/15 was a breaking version change and requires mapping

The removal of `social_engineering` and `poor_physical_security` also required a mapping.
