### PR TITLE
Add Flash-Based Open Redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+- unvalidated_redirects_and_forwards.open_redirect.flash_based
 
 ### Removed
 

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1102,6 +1102,12 @@
               "name": "Header-Based",
               "type": "variant",
               "priority": 5
+            },
+            {
+              "id": "flash_based",
+              "name": "Flash-Based",
+              "type": "variant",
+              "priority": 5
             }
           ]
         },


### PR DESCRIPTION
I've added flash-based open redirects as a P5 since it's almost always disabled by default on browsers, and the usage is consistently declining. I would say the low usage makes exploitability difficult enough that it can be argued as a "wont fix".

https://www.chromium.org/flash-roadmap/flash-usage-trends