### PR TITLE
Applicaton -> application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - missing_function_level_access_control.username_enumeration.data_leak moved via category change to broken_access_control.username_enumeration.data_leak
 - missing_function_level_access_control.exposed_sensitive_android_intent moved via category change to broken_access_control.exposed_sensitive_android_intent
 - missing_function_level_access_control.exposed_sensitive_ios_url_scheme moved via category change to broken_access_control.exposed_sensitive_ios_url_scheme
+- cross_site_request_forgery_csrf.application_wide name changed from Applicaton-Wide to Application-Wide
 
 ## [v1.2.0](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.1...v1.2) - 2017-08-04
 ### Added

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1006,7 +1006,7 @@
       "children": [
         {
           "id": "application_wide",
-          "name": "Applicaton-Wide",
+          "name": "Application-Wide",
           "type": "subcategory",
           "priority": 2
         },


### PR DESCRIPTION
Minor spelling mistake. Does not affect the node `id` so it should be backwards-compatible.