### PR TITLE
Fix invalid id in deprecated node mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_side_injection.sql_injection.blind
 
 ### Changed
+- references to the invalid insufficient_security_configurability.weak_password_policy.no_password_policy updated to insufficient_security_configurability.no_password_policy
 
 ## [v1.3.0](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.2...v1.3) - 2017-09-22
 ### Added
@@ -61,7 +62,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_security_misconfiguration.rfd
 - sensitive_data_exposure.xssi
 - server_security_misconfiguration.misconfigured_dns.zone_transfer
-- insufficient_security_configurability.weak_password_policy.no_password_policy
+- insufficient_security_configurability.no_password_policy
 - insecure_data_storage.server_side_credentials_storage
 - insecure_data_storage.server_side_credentials_storage.plaintext
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_security_misconfiguration.rfd
 - sensitive_data_exposure.xssi
 - server_security_misconfiguration.misconfigured_dns.zone_transfer
-- insufficient_security_configurability.no_password_policy
+- insufficient_security_configurability.no_password_policy (changelog text corrected in v1.4.0 #100)
 - insecure_data_storage.server_side_credentials_storage
 - insecure_data_storage.server_side_credentials_storage.plaintext
 

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -45,7 +45,7 @@
     "1.2": "insecure_data_storage.sensitive_application_data_stored_unencrypted.on_internal_storage"
   },
   "insufficient_security_configurability.weak_password_policy.complexity_both_length_and_char_type_not_enforced": {
-    "1.2": "insufficient_security_configurability.weak_password_policy.no_password_policy"
+    "1.2": "insufficient_security_configurability.no_password_policy"
   },
   "missing_function_level_access_control": {
     "1.3": "broken_access_control"


### PR DESCRIPTION
`insufficient_security_configurability.weak_password_policy.no_password_policy` doesn't actually exist in `1.2`, it was added as `insufficient_security_configurability.no_password_policy` (see #66). But the references in the deprecated node mapping and changelog used the wrong id. So:

1. How do we document this in the changelog? It's kinda a weird case, but I had a go. Open to suggestions.
2. Do we want to update the old info in the changelog? We possibly should because the old changelog entry doesn't correctly reflect what happened but on the other hand, editing info for old releases does seem kinda bad.
3. Was `no_password_policy` actually intended to be added as a child of `weak_password_policy`? I have no opinions on this I just want to check whether the mistake was in the documentation or the implementation.
4. We should add a test that the target of deprecated nodes is actually valid. But when I went to make the test, I got a little carried away so I'm making a separate PR about that.