### PR TITLE
Add changelog entry for v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_side_injection.sql_injection.blind
 
 ### Changed
-- references to the invalid insufficient_security_configurability.weak_password_policy.no_password_policy updated to insufficient_security_configurability.no_password_policy
 
 ## [v1.3.1](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3...v1.3.1) - 2017-10-31
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 - references to the invalid insufficient_security_configurability.weak_password_policy.no_password_policy updated to insufficient_security_configurability.no_password_policy
 
+## [v1.3.1](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3...v1.3.1) - 2017-10-31
+### Changed
+- references to the invalid insufficient_security_configurability.weak_password_policy.no_password_policy updated to insufficient_security_configurability.no_password_policy
+
 ## [v1.3.0](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.2...v1.3) - 2017-09-22
 ### Added
 - insecure_data_transport.cleartext_transmission_of_sensitive_data


### PR DESCRIPTION
We should keep our master changelog up to date, even though none of the commits for v1.3.1 are on this branch (they're all on [1.3-stable](https://github.com/bugcrowd/vulnerability-rating-taxonomy/tree/1.3-stable)). This duplicates the changelog entry for the backported fix between the unreleased and v1.3.1 sections but that is actually an accurate reflection of how it happened in the git tree so maybe it's okay. We can also remove that entry from Unreleased if people have strong opinions.