### PR TITLE
Update 'All Sessions' to 'Concurrent Sessions On Logout'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Changed
 - Use unittest for vrt validations
+- broken_authentication_and_session_management.failure_to_invalidate_session.all_sessions name changed from "All Sessions" to "Concurrent Sessions On Logout"
 
 ## [v1.3.1](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3...v1.3.1) - 2017-10-31
 ### Changed

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -626,7 +626,7 @@
             },
             {
               "id": "all_sessions",
-              "name": "All Sessions",
+              "name": "Concurrent Sessions On Logout",
               "type": "variant",
               "priority": 5
             },


### PR DESCRIPTION
As discussed internally we are updating the variant `Broken Authentication and Session Management->Failure to Invalidate Session->All Sessions` to `Broken Authentication and Session Management->Failure to Invalidate Session->Concurrent Sessions On Logout` to ensure clarity.

**Issue**: N/A

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: N/A

**[Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json)** (_if needed_): N/A
