### PR TITLE
remove mention of labeling within CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Bugcrowd welcomes community feedback and direct contributions to the Bugcrowd VRT. We accept comments for public discussion via GitHub Issues, but can also accommodate comments made via email to [vrt@bugcrowd.com](mailto:vrt@bugcrowd.com).
 
 ## Process
-Please open your feedback as an **Issue** and label it as either a `bug` or an `enhancement`. The Bugcrowd team strives to review and comment on new Issues within three business days. Large or systemic changes should first be discussed in an Issue rather than be submitted as a pull request directly. If you have a suggested minor change that includes:
+Please open your feedback as an **Issue**. The Bugcrowd team strives to review and comment on new Issues within three business days. Large or systemic changes should first be discussed in an Issue rather than be submitted as a pull request directly. If you have a suggested minor change that includes:
 
 - Additional subcategories or variants
 - Rewording of existing entries

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Bugcrowd welcomes community feedback and direct contributions to the Bugcrowd VRT. We accept comments for public discussion via GitHub Issues, but can also accommodate comments made via email to [vrt@bugcrowd.com](mailto:vrt@bugcrowd.com).
 
 ## Process
-Please open your feedback as an **Issue**. The Bugcrowd team strives to review and comment on new Issues within three business days. Large or systemic changes should first be discussed in an Issue rather than be submitted as a pull request directly. If you have a suggested minor change that includes:
+Please open your feedback as an **Issue**. The Bugcrowd team strives to review and comment on new Issues within five business days. Large or systemic changes should first be discussed in an Issue rather than be submitted as a pull request directly. If you have a suggested minor change that includes:
 
 - Additional subcategories or variants
 - Rewording of existing entries


### PR DESCRIPTION
Since labeling can only be done by contributors, we should not be asking new contributors to set them.

This was brought up by @edoverflow in #111.