### PR TITLE
Update all VRT to CWE mappings

### DIFF
--- a/mappings/cwe.json
+++ b/mappings/cwe.json
@@ -5,31 +5,19 @@
   "content": [
     {
       "id": "server_security_misconfiguration",
+      "cwe": ["CWE-933"],
       "children": [
         {
           "id": "unsafe_cross_origin_resource_sharing",
-          "cwe": ["CWE-933"]
+          "cwe": ["CWE-942"]
         },
         {
           "id": "path_traversal",
-          "cwe": ["CWE-38"]
+          "cwe": ["CWE-22", "CWE-73"]
         },
         {
           "id": "directory_listing_enabled",
-          "children": [
-            {
-              "id": "sensitive_data_exposure",
-              "cwe": ["CWE-538", "CWE-548", "CWE-552"]
-            },
-            {
-              "id": "non_sensitive_data_exposure",
-              "cwe": ["CWE-552"]
-            }
-          ]
-        },
-        {
-          "id": "same_site_scripting",
-          "cwe": ["CWE-933"]
+          "cwe": ["CWE-548"]
         },
         {
           "id": "ssl_attack_breach_poodle_etc",
@@ -37,28 +25,16 @@
         },
         {
           "id": "using_default_credentials",
-          "cwe": ["CWE-521"]
+          "cwe": ["CWE-255", "CWE-521"]
         },
         {
           "id": "misconfigured_dns",
           "children": [
             {
-              "id": "subdomain_takeover",
-              "cwe": ["CWE-933"]
-            },
-            {
               "id": "zone_transfer",
-              "cwe": ["CWE-0000000"]
-            },
-            {
-              "id": "missing_caa_record",
-              "cwe": ["CWE-0000000"]
+              "cwe": ["CWE-669"]
             }
           ]
-        },
-        {
-          "id": "mail_server_misconfiguration",
-          "cwe": ["CWE-933"]
         },
         {
           "id": "lack_of_password_confirmation",
@@ -67,10 +43,6 @@
             {
               "id": "change_password",
               "cwe": ["CWE-620"]
-            },
-            {
-              "id": "manage_two_fa",
-              "cwe": ["CWE-0000000"]
             }
           ]
         },
@@ -86,17 +58,12 @@
         },
         {
           "id": "unsafe_file_upload",
-          "cwe": ["CWE-933"],
           "children": [
             {
               "id": "file_extension_filter_bypass",
-              "cwe": ["CWE-434"]
+              "cwe": ["CWE-434", "CWE-646"]
             }
           ]
-        },
-        {
-          "id": "cookie_scoped_to_parent_domain",
-          "cwe": ["CWE-0000000"]
         },
         {
           "id": "missing_secure_or_httponly_cookie_flag",
@@ -108,35 +75,23 @@
         },
         {
           "id": "oauth_misconfiguration",
-          "cwe": ["CWE-933"]
+          "children": [
+            {
+              "id": "missing_state_parameter",
+              "cwe": ["CWE-352"]
+            }
+          ]
         },
         {
           "id": "captcha_bypass",
           "cwe": ["CWE-804"]
         },
         {
-          "id": "exposed_admin_portal",
-          "cwe": ["CWE-933"]
-        },
-        {
-          "id": "missing_dnssec",
-          "cwe": ["CWE-933"]
-        },
-        {
-          "id": "fingerprinting_banner_disclosure",
-          "cwe": ["CWE-0000000"]
-        },
-        {
           "id": "username_enumeration",
           "cwe": ["CWE-204"]
         },
         {
-          "id": "potentially_unsafe_http_method_enabled",
-          "cwe": ["CWE-933"]
-        },
-        {
           "id": "insecure_ssl",
-          "cwe": ["CWE-933"],
           "children": [
             {
               "id": "insecure_cipher_suite",
@@ -145,43 +100,31 @@
           ]
         },
         {
-          "id": "rfd",
-          "cwe": ["CWE-0000000"]
-        },
-        {
           "id": "lack_of_security_headers",
-          "cwe": ["CWE-933"],
           "children": [
             {
               "id": "cache_control_for_a_non_sensitive_page",
-              "cwe": ["CWE-933", "CWE-524"]
+              "cwe": ["CWE-525"]
             },
             {
               "id": "cache_control_for_a_sensitive_page",
-              "cwe": ["CWE-933", "CWE-524"]
+              "cwe": ["CWE-525"]
             }
           ]
-        },
-        {
-          "id": "bitsquatting",
-          "cwe": ["CWE-0000000"]
         }
       ]
     },
     {
       "id": "server_side_injection",
+      "cwe": ["CWE-929"],
       "children": [
         {
           "id": "file_inclusion",
-          "cwe": ["CWE-929"]
-        },
-        {
-          "id": "parameter_pollution",
-          "cwe": ["CWE-929"]
+          "cwe": ["CWE-73", "CWE-714"]
         },
         {
           "id": "remote_code_execution_rce",
-          "cwe": ["CWE-78"]
+          "cwe": ["CWE-77", "CWE-78", "CWE-94", "CWE-95"]
         },
         {
           "id": "sql_injection",
@@ -193,16 +136,27 @@
         },
         {
           "id": "http_response_manipulation",
-          "cwe": ["CWE-113"]
+          "children": [
+            {
+              "id": "response_splitting_crlf",
+              "cwe": ["CWE-113"]
+            }
+          ]
         },
         {
           "id": "content_spoofing",
-          "cwe": ["CWE-929"]
+          "children": [
+            {
+              "id": "homograph_idn_based",
+              "cwe": ["CWE-1007"]
+            }
+          ]
         }
       ]
     },
     {
       "id": "broken_authentication_and_session_management",
+      "cwe": ["CWE-930"],
       "children": [
         {
           "id": "authentication_bypass",
@@ -210,11 +164,16 @@
         },
         {
           "id": "privilege_escalation",
-          "cwe": ["CWE-0000000"]
+          "cwe": ["CWE-269"]
         },
         {
           "id": "weak_login_function",
-          "cwe": ["CWE-523"]
+          "children": [
+            {
+              "id": "over_http",
+              "cwe": ["CWE-523"]
+            }
+          ]
         },
         {
           "id": "session_fixation",
@@ -222,20 +181,26 @@
         },
         {
           "id": "failure_to_invalidate_session",
-          "cwe": ["CWE-930"]
+          "cwe": ["CWE-1018"]
         },
         {
           "id": "concurrent_logins",
-          "cwe": ["CWE-930"]
+          "cwe": ["CWE-1018"]
         },
         {
           "id": "weak_registration_implementation",
-          "cwe": ["CWE-311"]
+          "children": [
+            {
+              "id": "over_http",
+              "cwe": ["CWE-311"]
+            }
+          ]
         }
       ]
     },
     {
       "id": "sensitive_data_exposure",
+      "cwe": ["CWE-934"],
       "children": [
         {
           "id": "critically_sensitive_data",
@@ -246,17 +211,17 @@
             },
             {
               "id": "private_api_keys",
-              "cwe": ["CWE-311"]
+              "cwe": ["CWE-522"]
             }
           ]
         },
         {
           "id": "exif_geolocation_data_not_stripped_from_uploaded_images",
-          "cwe": ["CWE-934"]
+          "cwe": ["CWE-200"]
         },
         {
           "id": "visible_detailed_error_page",
-          "cwe": ["CWE-209"]
+          "cwe": ["CWE-209", "CWE-215"]
         },
         {
           "id": "disclosure_of_known_public_information",
@@ -264,11 +229,11 @@
         },
         {
           "id": "token_leakage_via_referer",
-          "cwe": ["CWE-311"]
+          "cwe": ["CWE-200"]
         },
         {
           "id": "sensitive_token_in_url",
-          "cwe": ["CWE-311"]
+          "cwe": ["CWE-200"]
         },
         {
           "id": "non_sensitive_token_in_url",
@@ -277,26 +242,6 @@
         {
           "id": "weak_password_reset_implementation",
           "cwe": ["CWE-640"]
-        },
-        {
-          "id": "mixed_content",
-          "cwe": ["CWE-3110000934"]
-        },
-        {
-          "id": "sensitive_data_hardcoded",
-          "cwe": ["CWE-934"]
-        },
-        {
-          "id": "internal_ip_disclosure",
-          "cwe": ["CWE-0000000"]
-        },
-        {
-          "id": "xssi",
-          "cwe": ["CWE-0000000"]
-        },
-        {
-          "id": "json_hijacking",
-          "cwe": ["CWE-0000000"]
         }
       ]
     },
@@ -306,6 +251,7 @@
     },
     {
       "id": "broken_access_control",
+      "cwe": ["CWE-723"],
       "children": [
         {
           "id": "idor",
@@ -325,7 +271,7 @@
         },
         {
           "id": "exposed_sensitive_ios_url_scheme",
-          "cwe": ["CWE-919"]
+          "cwe": ["CWE-939"]
         }
       ]
     },
@@ -344,12 +290,16 @@
         {
           "id": "open_redirect",
           "cwe": ["CWE-601"]
+        },
+        {
+          "id": "tabnabbing",
+          "cwe": ["CWE-1022"]
         }
       ]
     },
     {
       "id": "external_behavior",
-      "cwe": ["CWE-0000000"]
+      "cwe": ["CWE-2000"]
     },
     {
       "id": "insufficient_security_configurability",
@@ -361,7 +311,7 @@
         },
         {
           "id": "no_password_policy",
-          "cwe": ["CWE-0000000"]
+          "cwe": ["CWE-521"]
         },
         {
           "id": "weak_password_reset_implementation",
@@ -375,6 +325,7 @@
     },
     {
       "id": "insecure_data_storage",
+      "cwe": ["CWE-729", "CWE-922"],
       "children": [
         {
           "id": "sensitive_application_data_stored_unencrypted",
@@ -382,39 +333,38 @@
         },
         {
           "id": "server_side_credentials_storage",
-          "cwe": ["CWE-522"]
+          "cwe": ["CWE-522"],
+          "children": [
+            {
+              "id": "plaintext",
+              "cwe": ["CWE-256"]
+            }
+          ]
         },
         {
           "id": "non_sensitive_application_data_stored_unencrypted",
-          "cwe": ["CWE-0000000"]
-        },
-        {
-          "id": "screen_caching_enabled",
-          "cwe": ["CWE-0000000"]
+          "cwe": ["CWE-312"]
         }
       ]
     },
     {
       "id": "lack_of_binary_hardening",
-      "cwe": ["CWE-0000000"]
+      "cwe": ["CWE-2000"]
     },
     {
       "id": "insecure_data_transport",
+      "cwe": ["CWE-818"],
       "children": [
         {
           "id": "cleartext_transmission_of_sensitive_data",
-          "cwe": ["CWE-0000000"]
+          "cwe": ["CWE-319"]
         },
         {
           "id": "executable_download",
           "children": [
             {
               "id": "no_secure_integrity_check",
-              "cwe": ["CWE-0000000"]
-            },
-            {
-              "id": "secure_integrity_check",
-              "cwe": ["CWE-0000000"]
+              "cwe": ["CWE-353", "CWE-354", "CWE-494"]
             }
           ]
         }
@@ -443,17 +393,7 @@
     },
     {
       "id": "network_security_misconfiguration",
-      "children": [
-        {
-          "id": "telnet_enabled",
-          "children": [
-            {
-              "id": "credentials_required",
-              "cwe": ["CWE-0000000"]
-            }
-          ]
-        }
-      ]
+      "cwe": ["CWE-933"]
     },
     {
       "id": "mobile_security_misconfiguration",
@@ -461,22 +401,7 @@
     },
     {
       "id": "client_side_injection",
-      "cwe": ["CWE-929", "CWE-919"],
-      "children": [
-        {
-          "id": "binary_planting",
-          "children": [
-            {
-              "id": "privilege_escalation",
-              "cwe": ["CWE-0000000"]
-            },
-            {
-              "id": "no_privilege_escalation",
-              "cwe": ["CWE-0000000"]
-            }
-          ]
-        }
-      ]
+      "cwe": ["CWE-929"]
     }
   ]
 }


### PR DESCRIPTION
This is a general update of CWE mappings for #112. The default CWE mapping has been set to CWE-2000, this means that any top category that doesn't have a representation in CWE will have this mapping assigned (this also includes the "Other" category). Perhaps there's a more suitable choice...

Any feedback from the community is as always welcome and appreciated. Please note that our mapping logic allows all VRT child nodes to inherit their parent mappings in case a mapping for a specific child node is not explicitly defined. This makes for a concise mapping file structure.
