### PR TITLE
Use "third" over "3rd" for variant names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 - Use unittest for vrt validations
 - broken_authentication_and_session_management.failure_to_invalidate_session.all_sessions name changed from "All Sessions" to "Concurrent Sessions On Logout"
-- sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party name changed from 'Trusted 3rd Party' to 'Untrusted Third Party'
-- sensitive_data_exposure.token_leakage_via_referer.trusted_3rd_party name changed from 'Untrusted 3rd Party' to 'Trusted Third Party'
+- sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party name changed from 'Untrusted 3rd Party' to 'Untrusted Third Party'
+- sensitive_data_exposure.token_leakage_via_referer.trusted_3rd_party name changed from 'Trusted 3rd Party' to 'Trusted Third Party'
 
 ## [v1.3.1](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3...v1.3.1) - 2017-10-31
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 - Use unittest for vrt validations
 - broken_authentication_and_session_management.failure_to_invalidate_session.all_sessions name changed from "All Sessions" to "Concurrent Sessions On Logout"
+- sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party name changed from 'Trusted 3rd Party' to 'Untrusted Third Party'
+- sensitive_data_exposure.token_leakage_via_referer.trusted_3rd_party name changed from 'Untrusted 3rd Party' to 'Trusted Third Party'
 
 ## [v1.3.1](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3...v1.3.1) - 2017-10-31
 ### Changed

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -759,13 +759,13 @@
           "children": [
             {
               "id": "trusted_3rd_party",
-              "name": "Trusted 3rd Party",
+              "name": "Trusted Third Party",
               "type": "variant",
               "priority": 5
             },
             {
               "id": "untrusted_3rd_party",
-              "name": "Untrusted 3rd Party",
+              "name": "Untrusted Third Party",
               "type": "variant",
               "priority": 4
             },


### PR DESCRIPTION
Let's be consistent and not use numbers in the title if we can spell them. Replaces `3rd` in titles to `Third`
