### PR TITLE
Downgrade No Rate Limiting on Login to P4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
 - Use unittest for vrt validations
 - broken_authentication_and_session_management.failure_to_invalidate_session.all_sessions name changed from "All Sessions" to "Concurrent Sessions On Logout"
+- server_security_misconfiguration.no_rate_limiting_on_form.login priority changed from P3 to P4
 
 ## [v1.3.1](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3...v1.3.1) - 2017-10-31
 ### Changed

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -197,7 +197,7 @@
               "id": "login",
               "name": "Login",
               "type": "variant",
-              "priority": 3
+              "priority": 4
             },
             {
               "id": "email_triggering",


### PR DESCRIPTION
**Issue**: Resolves #127 

As discussed in the issue ^ it was decided to downgrade `Server Security Misconfiguration > No Rate Limiting on Form > Login` to P4. At the same time it's worth noting that if this entry is chained with Insufficient Security Configurability > No Password Policy, that would result in a P3 rating
