### PR TITLE
Downgrade weak P4's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_security_misconfiguration.oauth_misconfiguration.account_takeover
 - cross_site_scripting_xss.ie_only.ie11
 - cross_site_scripting_xss.ie_only.older_version_ie11
-- broken_authentication_and_session_management.failure_to_invalidate_session.server_side_only
+- broken_authentication_and_session_management.failure_to_invalidate_session.on_logout_server_side_only
 - sensitive_data_exposure.sensitive_token_in_url.user_facing
 - sensitive_data_exposure.sensitive_token_in_url.in_the_background
 - sensitive_data_exposure.sensitive_token_in_url.on_password_reset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,31 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - cross_site_scripting_xss.stored.url_based
 - server_security_misconfiguration.oauth_misconfiguration.insecure_redirect_uri
 - server_security_misconfiguration.oauth_misconfiguration.account_takeover
+- cross_site_scripting_xss.ie_only.ie11
+- cross_site_scripting_xss.ie_only.older_version_ie11
+- broken_authentication_and_session_management.failure_to_invalidate_session.server_side_only
+- sensitive_data_exposure.sensitive_token_in_url.user_facing
+- sensitive_data_exposure.sensitive_token_in_url.in_the_background
+- sensitive_data_exposure.sensitive_token_in_url.on_password_reset
 
 ### Removed
 - server_side_injection.sql_injection.error_based
 - server_side_injection.sql_injection.blind
+- cross_site_scripting_xss.ie_only.older_version_ie_10_11
+- cross_site_scripting_xss.ie_only.older_version_ie10
+- broken_authentication_and_session_management.failure_to_invalidate_session.on_password_reset
 
 ### Changed
 - Use unittest for vrt validations
 - broken_authentication_and_session_management.failure_to_invalidate_session.all_sessions name changed from "All Sessions" to "Concurrent Sessions On Logout"
 - server_security_misconfiguration.oauth_misconfiguration.missing_state_parameter name changed from "Missing State Parameter" to "Missing/Broken State Parameter"
 - server_security_misconfiguration.oauth_misconfiguration.missing_state_parameter priority changed from P4 to null
+- server_security_misconfiguration.lack_of_password_confirmation.change_email_address priority changed from P4 to P5
+- server_security_misconfiguration.lack_of_password_confirmation.change_password priority changed from P4 to P5
+- server_security_misconfiguration.unsafe_file_upload.no_antivirus priority changed from P4 to P5
+- server_security_misconfiguration.unsafe_file_upload.no_size_limit priority changed from P4 to P5
+- broken_authentication_and_session_management.failure_to_invalidate_session.on_logout name changed from "On Logout" to "On Logout (Client and Server-Side)"
+- broken_authentication_and_session_management.failure_to_invalidate_session.on_password_change name changed from "On Password Change" to "On Password Reset and/or Change"
 
 ## [v1.3.1](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3...v1.3.1) - 2017-10-31
 ### Changed

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -73,5 +73,14 @@
   },
   "insecure_direct_object_references_idor": {
     "1.3": "broken_access_control.idor"
+  },
+  "cross_site_scripting_xss.ie_only.older_version_ie_10_11": {
+    "1.4": "cross_site_scripting_xss.ie_only.ie11"
+  },
+  "cross_site_scripting_xss.ie_only.older_version_ie10": {
+    "1.4": "cross_site_scripting_xss.ie_only.older_version_ie11"
+  },
+  "broken_authentication_and_session_management.failure_to_invalidate_session.on_password_reset": {
+    "1.4": "broken_authentication_and_session_management.failure_to_invalidate_session.on_password_change"
   }
 }

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -90,11 +90,11 @@
         },
         {
           "id": "lack_of_password_confirmation",
-          "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:L",
+          "cvss_v3": "AV:P/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:L",
           "children": [
             {
               "id": "manage_two_fa",
-              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:L"
+              "cvss_v3": "AV:P/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:L"
             }
           ]
         },
@@ -113,11 +113,11 @@
           "children": [
             {
               "id": "no_antivirus",
-              "cvss_v3": "AV:N/AC:L/PR:N/UI:R/S:C/C:N/I:L/A:N"
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:C/C:N/I:L/A:N"
             },
             {
               "id": "no_size_limit",
-              "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L"
             },
             {
               "id": "file_extension_filter_bypass",
@@ -296,12 +296,12 @@
               "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N"
             },
             {
-              "id": "on_password_reset",
+              "id": "on_password_change",
               "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N"
             },
             {
-              "id": "on_password_change",
-              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N"
+              "id": "server_side_only",
+              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N"
             },
             {
               "id": "all_sessions",
@@ -466,7 +466,7 @@
           "id": "ie_only",
           "children": [
             {
-              "id": "older_version_ie_10_11",
+              "id": "ie11",
               "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
             },
             {
@@ -474,7 +474,7 @@
               "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
             },
             {
-              "id": "older_version_ie10",
+              "id": "older_version_ie11",
               "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N"
             }
           ]

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -296,12 +296,12 @@
               "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N"
             },
             {
-              "id": "on_password_change",
-              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N"
+              "id": "on_logout_server_side_only",
+              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N"
             },
             {
-              "id": "server_side_only",
-              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N"
+              "id": "on_password_change",
+              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:L/I:L/A:N"
             },
             {
               "id": "all_sessions",

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -160,13 +160,13 @@
               "id": "change_email_address",
               "name": "Change Email Address",
               "type": "variant",
-              "priority": 4
+              "priority": 5
             },
             {
               "id": "change_password",
               "name": "Change Password",
               "type": "variant",
-              "priority": 4
+              "priority": 5
             },
             {
               "id": "delete_account",
@@ -216,13 +216,13 @@
               "id": "no_antivirus",
               "name": "No Antivirus",
               "type": "variant",
-              "priority": 4
+              "priority": 5
             },
             {
               "id": "no_size_limit",
               "name": "No Size Limit",
               "type": "variant",
-              "priority": 4
+              "priority": 5
             },
             {
               "id": "file_extension_filter_bypass",
@@ -633,21 +633,21 @@
           "children": [
             {
               "id": "on_logout",
-              "name": "On Logout",
-              "type": "variant",
-              "priority": 4
-            },
-            {
-              "id": "on_password_reset",
-              "name": "On Password Reset",
+              "name": "On Logout (Client and Server-Side)",
               "type": "variant",
               "priority": 4
             },
             {
               "id": "on_password_change",
-              "name": "On Password Change",
+              "name": "On Password Reset and/or Change",
               "type": "variant",
               "priority": 4
+            },
+            {
+              "id": "server_side_only",
+              "name": "Server-Side Only",
+              "type": "variant",
+              "priority": 5
             },
             {
               "id": "all_sessions",
@@ -793,7 +793,26 @@
           "id": "sensitive_token_in_url",
           "name": "Sensitive Token in URL",
           "type": "subcategory",
-          "priority": 4
+          "children": [
+            {
+              "id": "user_facing",
+              "name": "User Facing",
+              "type": "variant",
+              "priority": 4
+            },
+            {
+              "id": "in_the_background",
+              "name": "In the Background",
+              "type": "variant",
+              "priority": 5
+            },
+            {
+              "id": "on_password_reset",
+              "name": "On Password Reset",
+              "type": "variant",
+              "priority": 5
+            }
+          ]
         },
         {
           "id": "non_sensitive_token_in_url",
@@ -926,8 +945,8 @@
           "type": "subcategory",
           "children": [
             {
-              "id": "older_version_ie_10_11",
-              "name": "Older Version (IE 10/11)",
+              "id": "ie11",
+              "name": "IE11",
               "type": "variant",
               "priority": 4
             },
@@ -938,8 +957,8 @@
               "priority": 5
             },
             {
-              "id": "older_version_ie10",
-              "name": "Older Version (< IE10)",
+              "id": "older_version_ie11",
+              "name": "Older Version (< IE11)",
               "type": "variant",
               "priority": 5
             }

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -638,16 +638,16 @@
               "priority": 4
             },
             {
+              "id": "on_logout_server_side_only",
+              "name": "On Logout (Server-Side Only)",
+              "type": "variant",
+              "priority": 5
+            },
+            {
               "id": "on_password_change",
               "name": "On Password Reset and/or Change",
               "type": "variant",
               "priority": 4
-            },
-            {
-              "id": "server_side_only",
-              "name": "Server-Side Only",
-              "type": "variant",
-              "priority": 5
             },
             {
               "id": "all_sessions",


### PR DESCRIPTION
**Issue**: Resolves #133 

**[Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json)**:
- `cross_site_scripting_xss.ie_only.older_version_ie_10_11` to `cross_site_scripting_xss.ie_only.ie11`
- `cross_site_scripting_xss.ie_only.older_version_ie10`to  `cross_site_scripting_xss.ie_only.older_version_ie11`
- `broken_authentication_and_session_management.failure_to_invalidate_session.on_password_reset` to `broken_authentication_and_session_management.failure_to_invalidate_session.on_password_change`

Let's triple check that these changes make sense

P.S. Looks like there might be some test problems due to 1.3.1 version interfering with 1.4


