### PR TITLE
Update readme with VRT Council

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ At the beginning 2016, we released the Bugcrowd Vulnerability Rating Taxonomy (V
 
 In April 2017 we decided to open source our taxonomy and published formal contributor guidelines for the VRT, allowing us to gain additional insight from the public and transparently communicate about any feedback.
 
-## Vulnerability Roundtable
-Each week several members of the Bugcrowd team hold a roundtable where they discuss vulnerability edge cases, improving vulnerability classification, questions around general bug validation, and all external feedback. When the team comes to a consensus regarding each change proposed to the VRT, it is committed to this repository. Members of the Security Operations team in particular look forward to this meeting each week, as examining some of the most difficult to validate bugs serves as a unique learning exercise. We have decided to publish minutes from the VRT oriented part of the Vulnerability Roundtable to allow even more transparency and will be sharing those [here](https://github.com/bugcrowd/vulnerability-rating-taxonomy/wiki/Vulnerability-Roundtable-Minutes).
+## VRT Council
+Each week several members of the Bugcrowd team hold a meeting where they discuss vulnerability edge cases, improving vulnerability classification and all external VRT feedback. When the team comes to a consensus regarding each change proposed to the VRT, it is committed to this repository. We have decided to publish minutes from the VRT Council meeting to allow even more transparency and will be sharing those [here](https://github.com/bugcrowd/vulnerability-rating-taxonomy/wiki/VRT-Council-minutes).
 
 ## Description
 Bugcrowd's VRT outlines Bugcrowd's baseline technical severity rating – taking into account potential differences among edge cases – for common vulnerability classes. To arrive at this baseline technical severity rating for a given vulnerability, Bugcrowd's application security engineers started with the generally-accepted industry guideline and further considered the vulnerability's average acceptance rate, average priority, and frequency on business use case specific exclusions lists across all of Bugcrowd's programs.


### PR DESCRIPTION
Vulnerability Roundtable has been divided into two separate meetings: Vulnerability Roundtable and VRT Council. VRT Council will be focusing on VRT related issues specifically and the proposed readme changes reflect that.