### PR TITLE
Allow versions greater than the last tag in the deprecated node mapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7
 
-RUN pip install jsonschema GitPython
+RUN pip install jsonschema GitPython semantic_version
 
 WORKDIR /tmp/vrt
 CMD [ "python" , "./validate_vrt.py" ]

--- a/tests/test_deprecated_mapping.py
+++ b/tests/test_deprecated_mapping.py
@@ -1,10 +1,12 @@
 import utils
 import unittest
+from semantic_version import Version
 
 
 class TestDeprecatedMapping(unittest.TestCase):
     def setUp(self):
         self.vrt_versions = utils.all_versions(utils.VRT_FILENAME)
+        self.last_tagged_version = max([Version.coerce(x) for x in self.vrt_versions.keys() if x != 'current'])
         self.deprecated_json = utils.get_json(utils.DEPRECATED_MAPPING_FILENAME)
 
     def test_old_vrt_ids_have_current_node(self):
@@ -23,7 +25,7 @@ class TestDeprecatedMapping(unittest.TestCase):
     def test_deprecated_nodes_map_valid_node(self):
         for old_id, mapping in self.deprecated_json.iteritems():
             for new_version, new_id in mapping.iteritems():
-                self.assertTrue(new_id == 'other' or utils.id_valid(self.vrt_versions[new_version], new_id.split('.')),
+                self.assertTrue(new_id == 'other' or utils.id_valid(self.vrt_version(new_version), new_id.split('.')),
                                 new_id + ' is not valid')
 
     def check_mapping(self, id_list):
@@ -34,6 +36,13 @@ class TestDeprecatedMapping(unittest.TestCase):
         else:
             return self.check_mapping(id_list[0:-1])
 
+    def vrt_version(self, version):
+        if version in self.vrt_versions:
+            return self.vrt_versions[version]
+        elif Version.coerce(version) > self.last_tagged_version:
+            return self.vrt_versions['current']
+        else:
+            self.fail('Unknown version: %s' % version)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
When removing ids, it makes sense to add the entries to the deprecated node mapping before the next release is made. In that case, we should check the id is valid based on the current branch, rather than erroring out with an unknown version.

Fixes the build errors in https://github.com/bugcrowd/vulnerability-rating-taxonomy/pull/138

#### To test

```
git checkout downgrade-weak-p4s
docker build -t vrt .
docker run -v $(pwd):/tmp/vrt vrt # should fail
git merge --no-commit fix-deprecated-node-test
docker build -t vrt .
docker run -v $(pwd):/tmp/vrt vrt # should pass
```