### PR TITLE
Remove 'Network Security Misconfiguration > Telnet Enabled > Credentials Required'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Removed
 - server_side_injection.sql_injection.error_based
 - server_side_injection.sql_injection.blind
+- network_security_misconfiguration.telnet_enabled.credentials_required
 
 ### Changed
 - Use unittest for vrt validations
@@ -23,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_security_misconfiguration.oauth_misconfiguration.missing_state_parameter name changed from "Missing State Parameter" to "Missing/Broken State Parameter"
 - server_security_misconfiguration.oauth_misconfiguration.missing_state_parameter priority changed from P4 to null
 - server_security_misconfiguration.no_rate_limiting_on_form.login priority changed from P3 to P4
+- network_security_misconfiguration.telnet_enabled priority changed from null to P5 (due to children removal)
 
 ## [v1.3.1](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3...v1.3.1) - 2017-10-31
 ### Changed

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -73,5 +73,8 @@
   },
   "insecure_direct_object_references_idor": {
     "1.3": "broken_access_control.idor"
+  },
+  "network_security_misconfiguration.telnet_enabled.credentials_required": {
+    "1.4": "broken_authentication_and_session_management.weak_login_function.other_plaintext_protocol_no_secure_alternative"
   }
 }

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -706,12 +706,7 @@
       "children": [
         {
           "id": "telnet_enabled",
-          "children": [
-            {
-              "id": "credentials_required",
-              "cvss_v3": "AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:L/A:N"
-            }
-          ]
+          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
         }
       ]
     },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1564,14 +1564,7 @@
           "id": "telnet_enabled",
           "name": "Telnet Enabled",
           "type": "subcategory",
-          "children": [
-            {
-              "id": "credentials_required",
-              "name": "Credentials Required",
-              "type": "variant",
-              "priority": 4
-            }
-          ]
+          "priority": 5
         }
       ]
     },


### PR DESCRIPTION
**Issue**: Resolves #140 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: `network_security_misconfiguration.telnet_enabled` [AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N)

**[Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json)**: `network_security_misconfiguration.telnet_enabled.credentials_required` to `broken_authentication_and_session_management.weak_login_function.other_plaintext_protocol_no_secure_alternative`
