### PR TITLE
Fix changelog for #142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_security_misconfiguration.oauth_misconfiguration.missing_state_parameter name changed from "Missing State Parameter" to "Missing/Broken State Parameter"
 - server_security_misconfiguration.oauth_misconfiguration.missing_state_parameter priority changed from P4 to null
 - server_security_misconfiguration.no_rate_limiting_on_form.login priority changed from P3 to P4
-- client_side_injection.binary_planting.privilege_escalation name changed from "Privilege Escalation" to "Default Folder Privilege Escalation"
+- client_side_injection.binary_planting.privilege_escalation name changed from "Privilege Escalation" to "Default Folder Privilege Escalation" priority changed from P4 to P3
 - server_security_misconfiguration.lack_of_password_confirmation.change_email_address priority changed from P4 to P5
 - server_security_misconfiguration.lack_of_password_confirmation.change_password priority changed from P4 to P5
 - server_security_misconfiguration.unsafe_file_upload.no_antivirus priority changed from P4 to P5


### PR DESCRIPTION
Adding missing information to the changelog regarding priority update for `client_side_injection.binary_planting.privilege_escalation` that was done in #142