### PR TITLE
Add Flash-Based variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+- unvalidated_redirects_and_forwards.open_redirect.flash_based
+- cross_site_scripting_xss.flash_based
+- server_side_injection.content_spoofing.flash_based_external_authentication_injection
 
 ### Removed
 

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -253,6 +253,10 @@
               "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
             },
             {
+              "id": "flash_based_external_authentication_injection",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
+            },
+            {
               "id": "email_html_injection",
               "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
             }
@@ -469,6 +473,10 @@
               "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
             }
           ]
+        },
+        {
+          "id": "flash_based",
+          "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
         },
         {
           "id": "cookie_based",

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -544,6 +544,10 @@
               ]
             },
             {
+              "id": "flash_based_external_authentication_injection",
+              "remediation_advice": "Even if unsafe HTML tags like `<script>` or `<iframe>` are filtered out from user input, it is possible to inject `HTTP 401` authentication prompt into Flash content. In order to prevent this type of injection consider the following solutions:\n\n1. Always treat all user input as untrusted data.\n2. Always input or output encode all data coming into or out of the application.\n3. Always whitelist allowed characters and seldom use blacklisting of characters unless in certain use cases.\n4. Always use a well known and security encoding API for input and output encoding such as the `OWASP ESAPI`.\n5. Never try to write input and output encoders unless absolutely necessary. Chances are that someone has already written a good one."
+            },
+            {
               "id": "email_html_injection",
               "remediation_advice": "Always ensure that email contents cannot be tampered with. Limit what the user can insert into the email by filtering special characters and limiting the amount of characters that can be inserted. Additionally, filter out any URLs as they are often rendered as links by email providers.",
               "references": [

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -550,6 +550,12 @@
               "priority": 4
             },
             {
+              "id": "flash_based_external_authentication_injection",
+              "name": "Flash Based External Authentication Injection",
+              "type": "variant",
+              "priority": 5
+            },
+            {
               "id": "email_html_injection",
               "name": "Email HTML Injection",
               "type": "variant",
@@ -945,6 +951,12 @@
           ]
         },
         {
+          "id": "flash_based",
+          "name": "Flash-Based",
+          "type": "subcategory",
+          "priority": 4
+        },
+        {
           "id": "cookie_based",
           "name": "Cookie-Based",
           "type": "subcategory",
@@ -1166,6 +1178,12 @@
             {
               "id": "header_based",
               "name": "Header-Based",
+              "type": "variant",
+              "priority": 5
+            },
+            {
+              "id": "flash_based",
+              "name": "Flash-Based",
               "type": "variant",
               "priority": 5
             }


### PR DESCRIPTION
**Issue**: Resolves #120

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**:
`cross_site_scripting_xss.flash_based` [AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N)
`server_side_injection.content_spoofing.flash_based_external_authentication_injection` [AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N)
`unvalidated_redirects_and_forwards.open_redirect.flash_based` default as the category

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**: Reused `server_side_injection.content_spoofing.external_authentication_injection` with minor adjustments

---

Even if unsafe HTML tags like `<script>` or `<iframe>` are filtered out from user input, it is possible to inject `HTTP 401` authentication prompt into Flash content. In order to prevent this type of injection consider the following solutions:

1. Always treat all user input as untrusted data.
2. Always input or output encode all data coming into or out of the application.
3. Always whitelist allowed characters and seldom use blacklisting of characters unless in certain use cases.
4. Always use a well known and security encoding API for input and output encoding such as the `OWASP ESAPI`.
5. Never try to write input and output encoders unless absolutely necessary. Chances are that someone has already written a good one.