### PR TITLE
Simplify CWE mapping / Use nodes in the "Research" view

### DIFF
--- a/mappings/cwe.json
+++ b/mappings/cwe.json
@@ -5,7 +5,7 @@
   "content": [
     {
       "id": "server_security_misconfiguration",
-      "cwe": ["CWE-933"],
+      "cwe": ["CWE-16"],
       "children": [
         {
           "id": "unsafe_cross_origin_resource_sharing",
@@ -13,7 +13,7 @@
         },
         {
           "id": "path_traversal",
-          "cwe": ["CWE-22", "CWE-73"]
+          "cwe": ["CWE-22"]
         },
         {
           "id": "directory_listing_enabled",
@@ -25,7 +25,7 @@
         },
         {
           "id": "using_default_credentials",
-          "cwe": ["CWE-255", "CWE-521"]
+          "cwe": ["CWE-798"]
         },
         {
           "id": "misconfigured_dns",
@@ -69,7 +69,7 @@
           "children": [
             {
               "id": "file_extension_filter_bypass",
-              "cwe": ["CWE-434", "CWE-646"]
+              "cwe": ["CWE-646"]
             }
           ]
         },
@@ -91,7 +91,7 @@
             },
             {
               "id": "insecure_redirect_uri",
-              "cwe": ["CWE-938"]
+              "cwe": ["CWE-601"]
             }
           ]
         },
@@ -129,11 +129,11 @@
     },
     {
       "id": "server_side_injection",
-      "cwe": ["CWE-929"],
+      "cwe": ["CWE-89"],
       "children": [
         {
           "id": "file_inclusion",
-          "cwe": ["CWE-73", "CWE-714"]
+          "cwe": ["CWE-73"]
         },
         {
           "id": "remote_code_execution_rce",
@@ -169,7 +169,7 @@
     },
     {
       "id": "broken_authentication_and_session_management",
-      "cwe": ["CWE-930"],
+      "cwe": ["CWE-287"],
       "children": [
         {
           "id": "authentication_bypass",
@@ -189,11 +189,11 @@
         },
         {
           "id": "failure_to_invalidate_session",
-          "cwe": ["CWE-1018"]
+          "cwe": ["CWE-613"]
         },
         {
           "id": "concurrent_logins",
-          "cwe": ["CWE-1018"]
+          "cwe": ["CWE-264"]
         },
         {
           "id": "weak_registration_implementation",
@@ -229,7 +229,7 @@
         },
         {
           "id": "visible_detailed_error_page",
-          "cwe": ["CWE-209", "CWE-215"]
+          "cwe": ["CWE-209"]
         },
         {
           "id": "disclosure_of_known_public_information",
@@ -263,11 +263,11 @@
       "children": [
         {
           "id": "idor",
-          "cwe": ["CWE-932"]
+          "cwe": ["CWE-639"]
         },
         {
           "id": "server_side_request_forgery_ssrf",
-          "cwe": ["CWE-918"]
+          "cwe": ["CWE-441"]
         },
         {
           "id": "username_enumeration",
@@ -293,7 +293,7 @@
     },
     {
       "id": "unvalidated_redirects_and_forwards",
-      "cwe": ["CWE-938"],
+      "cwe": ["CWE-601"],
       "children": [
         {
           "id": "open_redirect",
@@ -311,7 +311,7 @@
     },
     {
       "id": "insufficient_security_configurability",
-      "cwe": ["CWE-933"],
+      "cwe": ["CWE-287"],
       "children": [
         {
           "id": "weak_password_policy",
@@ -329,11 +329,11 @@
     },
     {
       "id": "using_components_with_known_vulnerabilities",
-      "cwe": ["CWE-937"]
+      "cwe": ["CWE-829"]
     },
     {
       "id": "insecure_data_storage",
-      "cwe": ["CWE-729", "CWE-922"],
+      "cwe": ["CWE-311"],
       "children": [
         {
           "id": "sensitive_application_data_stored_unencrypted",
@@ -361,7 +361,7 @@
     },
     {
       "id": "insecure_data_transport",
-      "cwe": ["CWE-818"],
+      "cwe": ["CWE-311"],
       "children": [
         {
           "id": "cleartext_transmission_of_sensitive_data",
@@ -401,15 +401,15 @@
     },
     {
       "id": "network_security_misconfiguration",
-      "cwe": ["CWE-933"]
+      "cwe": ["CWE-16"]
     },
     {
       "id": "mobile_security_misconfiguration",
-      "cwe": ["CWE-919"]
+      "cwe": ["CWE-16"]
     },
     {
       "id": "client_side_injection",
-      "cwe": ["CWE-929"]
+      "cwe": ["CWE-943"]
     }
   ]
 }

--- a/mappings/cwe.json
+++ b/mappings/cwe.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "default": ["CWE-2000"]
+    "default": ["CWE-1000"]
   },
   "content": [
     {
@@ -307,7 +307,7 @@
     },
     {
       "id": "external_behavior",
-      "cwe": ["CWE-2000"]
+      "cwe": ["CWE-16"]
     },
     {
       "id": "insufficient_security_configurability",
@@ -357,7 +357,7 @@
     },
     {
       "id": "lack_of_binary_hardening",
-      "cwe": ["CWE-2000"]
+      "cwe": ["CWE-693"]
     },
     {
       "id": "insecure_data_transport",


### PR DESCRIPTION
This PR is an attempt to simplify the CWE mapping.

First, it updates the mapping to ONLY nodes relevant to a singular view: "Research / CWE-1000" . Secondly, In cases where a VRT entry is linked to multiple CWE nodes, an attempt was made to simplify to a single node. This was not always possible, so some entries still contain multiple.

Some relevant background reading on views is helpful in explaining CWE and why i'm PR'ing this: https://cwe.mitre.org/documents/cwe_usage/mapping_navigation.html

In short, views can be thought of as standalone tree or graph views of CWE. Because some of the current CWE mappings belonged to the OWASP Top 10 view (https://cwe.mitre.org/data/definitions/928.html) and others belonged to the Research View (https://cwe.mitre.org/data/definitions/1000.html), the mapping was getting messy, and this spells trouble for anyone wanting to actually use this mapping.

An aside: It's not clear why the OWASP nodes are separated from existing nodes in CWE, there's a bunch of redundancy. Regardless, the Research view is the most well maintained, and i believe what the VRT should map to exclusively. the OWASP Top Ten view does not aim to be comprehensive, nor does it appear built out or well maintained.

I'll conclude with the statement that there's more work to do with the CWE mapping - mapping currently-unmapped nodes - but this at least allows a simplified, solid foundation. Going forward, if all links are made to nodes contained in the Research view, you will minimize redundent links This snippet from the link above should be a guide going forward:
> To determine whether you have found the best matching CWE ID for a 
> particular weakness, consider the following:
>
> The entry should be a Weakness or Composite/Chain type. Mapping to a View is 
> incorrect, and mapping to a Category is strongly discouraged, because categories 
> are not centered around CWE's behavioral model of weaknesses.
>
> The entry should be at the lowest level of abstraction possible, while matching 
> (or subsuming) the weakness concept that you have in mind. Be aware that CWE 
> cannot support all possible perspectives and ways of classifying weaknesses, so 
> sometimes there will not be a suitable match, except at a very high level; see the
>  "Mapping Analysis" document for a discussion of the issues.

Updated **[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**

Hopefully this helps!