### PR TITLE
Revise email spoofing variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - mobile_security_misconfiguration.clipboard_enabled.on_sensitive_content
 - mobile_security_misconfiguration.clipboard_enabled.on_non_sensitive_content
 - server_security_misconfiguration.waf_bypass.direct_server_access
+- server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domain
 
 ### Removed
+- server_security_misconfiguration.mail_server_misconfiguration.missing_spf_on_email_domain
+- server_security_misconfiguration.mail_server_misconfiguration.email_spoofable_via_third_party_api_misconfiguration
 
 ### Changed
 - broken_authentication_and_session_management.failure_to_invalidate_session.on_password_change updated remediation advice

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -90,9 +90,9 @@
     "1.4": "broken_authentication_and_session_management.weak_login_function.other_plaintext_protocol_no_secure_alternative"
   },
   "server_security_misconfiguration.mail_server_misconfiguration.missing_spf_on_email_domain": {
-    "1.5": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domainn"
+    "1.5": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domain"
   },
   "server_security_misconfiguration.mail_server_misconfiguration.email_spoofable_via_third_party_api_misconfiguration": {
-    "1.5": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domainn"
+    "1.5": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domain"
   }
 }

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -88,5 +88,11 @@
   },
   "network_security_misconfiguration.telnet_enabled.credentials_required": {
     "1.4": "broken_authentication_and_session_management.weak_login_function.other_plaintext_protocol_no_secure_alternative"
+  },
+  "server_security_misconfiguration.mail_server_misconfiguration.missing_spf_on_email_domain": {
+    "1.5": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domainn"
+  },
+  "server_security_misconfiguration.mail_server_misconfiguration.email_spoofable_via_third_party_api_misconfiguration": {
+    "1.5": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domainn"
   }
 }

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -61,7 +61,7 @@
           "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N",
           "children": [
             {
-              "id": "mail_spoofing_on_email_domain",
+              "id": "email_spoofing_on_email_domain",
               "cvss_v3": "AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
             }
           ]

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -61,11 +61,7 @@
           "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N",
           "children": [
             {
-              "id": "missing_spf_on_email_domain",
-              "cvss_v3": "AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
-            },
-            {
-              "id": "email_spoofable_via_third_party_api_misconfiguration",
+              "id": "mail_spoofing_on_email_domain",
               "cvss_v3": "AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N"
             }
           ]

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -91,16 +91,12 @@
           "id": "mail_server_misconfiguration",
           "children": [
             {
-              "id": "missing_spf_on_email_domain",
-              "remediation_advice": "Create a `Sender Policy Framework` record for the domain in which your emails originate. This will help prevent attackers from sending spoof emails that may look like they originate from your domain. The SPF record will be configurable by your DNS host as a `txt` record.  Check with your registrar and your email provider on specific entries. It should look similar to:\n`v=spf1 include:_IP.or.Domain.Here -all`.",
+              "id": "email_spoofing_on_email_domain",
+              "remediation_advice": "1. Create a `Sender Policy Framework` record for the domain in which your emails originate. This will help prevent attackers from sending spoof emails that may look like they originate from your domain. The SPF record will be configurable by your DNS host as a `txt` record.  Check with your registrar and your email provider on specific entries. It should look similar to:\n`v=spf1 include:_IP.or.Domain.Here -all`.\n2. Ensure that there are restrictions in place on who can send emails using your SMTP server and/or the API.",
               "references": [
                 "http://www.openspf.org/SPF_Record_Syntax",
                 "https://support.google.com/a/answer/33786?hl=en"
               ]
-            },
-            {
-              "id": "email_spoofable_via_third_party_api_misconfiguration",
-              "remediation_advice": "Ensure that there are restrictions in place on who can send emails using your account."
             },
             {
               "id": "missing_spf_on_non_email_domain",

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -88,14 +88,8 @@
           "type": "subcategory",
           "children": [
             {
-              "id": "missing_spf_on_email_domain",
-              "name": "Missing SPF on Email Domain",
-              "type": "variant",
-              "priority": 3
-            },
-            {
-              "id": "email_spoofable_via_third_party_api_misconfiguration",
-              "name": "Email Spoofable Via Third-Party API Misconfiguration",
+              "id": "email_spoofing_on_email_domain",
+              "name": "Email Spoofing on Email Domain",
               "type": "variant",
               "priority": 3
             },


### PR DESCRIPTION
**Issue**: Resolves #167 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: No change - [AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: No change - none

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**: Merged -
"1. Create a `Sender Policy Framework` record for the domain in which your emails originate. This will help prevent attackers from sending spoof emails that may look like they originate from your domain. The SPF record will be configurable by your DNS host as a `txt` record.  Check with your registrar and your email provider on specific entries. It should look similar to:\n`v=spf1 include:_IP.or.Domain.Here -all`.
2. Ensure that there are restrictions in place on who can send emails using your SMTP server and/or the API.",

**[Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json)** (_if needed_):
```
"server_security_misconfiguration.mail_server_misconfiguration.missing_spf_on_email_domain": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domain"

"server_security_misconfiguration.mail_server_misconfiguration.email_spoofable_via_third_party_api_misconfiguration": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domain"
```
