### PR TITLE
Add no rate limit on SMS triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - mobile_security_misconfiguration.clipboard_enabled.on_non_sensitive_content
 - server_security_misconfiguration.waf_bypass.direct_server_access
 - broken_authentication_and_session_management.two_fa_bypass
+- server_security_misconfiguration.no_rate_limiting_on_form.sms_triggering
 
 ### Removed
 

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -186,6 +186,10 @@
             {
               "id": "email_triggering",
               "remediation_advice": "1. Use a `CAPTCHA` to limit email triggering requests.\n2. Use a rate limit per IP address to throttle the amount of email triggering requests that can be made in a certain amount of time."
+            },
+            {
+              "id": "sms_triggering",
+              "remediation_advice": "1. Use a `CAPTCHA` to limit SMS triggering requests.\n2. Use a rate limit per IP address to throttle the amount of SMS triggering requests that can be made in a certain amount of time."
             }
           ]
         },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -191,6 +191,12 @@
               "name": "Email-Triggering",
               "type": "variant",
               "priority": 4
+            },
+            {
+              "id": "sms_triggering",
+              "name": "SMS-Triggering",
+              "type": "variant",
+              "priority": 4
             }
           ]
         },


### PR DESCRIPTION
**Issue**: Resolves #169 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: Inherited from the parent [AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:L/A:N)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: Inherited from the parent [CWE-799](https://cwe.mitre.org/data/definitions/799.html)

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**:
```
1. Use a `CAPTCHA` to limit SMS triggering requests.
2. Use a rate limit per IP address to throttle the amount of SMS triggering requests that can be made in a certain amount of time.
```
