### PR TITLE
Revise Stored XSS > Admin to Anyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_security_misconfiguration.no_rate_limiting_on_form.sms_triggering
 - server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domain
 - server_security_misconfiguration.insecure_ssl.certificate_error
+- cross_site_scripting_xss.stored.privileged_user_to_privilege_elevation
+- cross_site_scripting_xss.stored.privileged_user_to_no_privilege_elevation
 
 ### Removed
 - server_security_misconfiguration.mail_server_misconfiguration.missing_spf_on_email_domain
 - server_security_misconfiguration.mail_server_misconfiguration.email_spoofable_via_third_party_api_misconfiguration
+- cross_site_scripting_xss.stored.admin_to_anyone
 
 ### Changed
 - broken_authentication_and_session_management.failure_to_invalidate_session.on_password_change updated remediation advice
 - CWE mapping default changed from `[CWE-2000]` to `null`
 - Updated python version to 3.6
+- cross_site_scripting_xss.stored.non_admin_to_anyone name changed from "Non-Admin to Anyone" to "Non-Privileged User to Anyone"
 
 ## [v1.4](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3.1...v1.4) - 2018-04-13
 ### Added

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -94,5 +94,8 @@
   },
   "server_security_misconfiguration.mail_server_misconfiguration.email_spoofable_via_third_party_api_misconfiguration": {
     "1.5": "server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_email_domain"
+  },
+  "cross_site_scripting_xss.stored.admin_to_anyone": {
+    "1.5": "cross_site_scripting_xss.stored.privileged_user_to_privilege_elevation"
   }
 }

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -467,11 +467,15 @@
           "children": [
             {
               "id": "non_admin_to_anyone",
-              "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
+              "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N"
             },
             {
-              "id": "admin_to_anyone",
-              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:N"
+              "id": "privileged_user_to_privilege_elevation",
+              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:N"
+            },
+            {
+              "id": "privileged_user_to_no_privilege_elevation",
+              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:C/C:L/I:L/A:N"
             },
             {
               "id": "url_based",

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -951,15 +951,21 @@
           "children": [
             {
               "id": "non_admin_to_anyone",
-              "name": "Non-Admin to Anyone",
+              "name": "Non-Privileged User to Anyone",
               "type": "variant",
               "priority": 2
             },
             {
-              "id": "admin_to_anyone",
-              "name": "Admin to Anyone",
+              "id": "privileged_user_to_privilege_elevation",
+              "name": "Privileged User to Privilege Elevation",
               "type": "variant",
               "priority": 3
+            },
+            {
+              "id": "privileged_user_to_no_privilege_elevation",
+              "name": "Privileged User to No Privilege Elevation",
+              "type": "variant",
+              "priority": 4
             },
             {
               "id": "url_based",


### PR DESCRIPTION
**Issue**: Resolves #166 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**:
`privileged_user_to_privilege_elevation`: [AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:H/I:H/A:N)
`privileged_user_to_no_privilege_elevation`: [AV:N/AC:L/PR:H/UI:N/S:C/C:L/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:H/UI:N/S:C/C:L/I:L/A:N)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: N/A (inherited from the parent)

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**: N/A (inherited from the parent)

**[Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json)**: `cross_site_scripting_xss.stored.admin_to_anyone` maps to the new `cross_site_scripting_xss.stored.privileged_user_to_privilege_elevation`
