### PR TITLE
Revise Clickjacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_security_misconfiguration.insecure_ssl.certificate_error
 - cross_site_scripting_xss.stored.privileged_user_to_privilege_elevation
 - cross_site_scripting_xss.stored.privileged_user_to_no_privilege_elevation
+- server_security_misconfiguration.clickjacking.form_input
 
 ### Removed
 - server_security_misconfiguration.mail_server_misconfiguration.missing_spf_on_email_domain
@@ -33,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - CWE mapping default changed from `[CWE-2000]` to `null`
 - Updated python version to 3.6
 - cross_site_scripting_xss.stored.non_admin_to_anyone name changed from "Non-Admin to Anyone" to "Non-Privileged User to Anyone"
+- server_security_misconfiguration.clickjacking.sensitive_action name changed from "Sensitive Action" to "Sensitive Click-Based Action"
 
 ## [v1.4](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.3.1...v1.4) - 2018-04-13
 ### Added

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -137,6 +137,10 @@
               "cvss_v3": "AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N"
             },
             {
+              "id": "form_input",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
+            },
+            {
               "id": "non_sensitive_action",
               "cvss_v3": "AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:N"
             }

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -246,6 +246,10 @@
               "remediation_advice": "1. Use the `X-Frame-Options: DENY` HTTP response header on pages with sensitive information, to disallow framing of the page on external resources.\n2. In the case where `DENY` is not an option, use `X-Frame-Options: SAMEORIGIN`.\n3. In the case where `SAMEORIGIN` is not an option, `X-Frame-Options: ALLOW-FROM https://example.com/`."
             },
             {
+              "id": "form_input",
+              "remediation_advice": "1. Use the `X-Frame-Options: DENY` HTTP response header on pages with sensitive information, to disallow framing of the page on external resources.\n2. In the case where `DENY` is not an option, use `X-Frame-Options: SAMEORIGIN`.\n3. In the case where `SAMEORIGIN` is not an option, `X-Frame-Options: ALLOW-FROM https://example.com/`."
+            },
+            {
               "id": "non_sensitive_action",
               "remediation_advice": "As a best practice, consider adding the `X-FRAME-OPTIONS: SAMEORIGIN` HTTP response header to all responses going to the user's browser to avoid unnecessary cross-origin iframe access."
             }

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -251,9 +251,15 @@
           "children": [
             {
               "id": "sensitive_action",
-              "name": "Sensitive Action",
+              "name": "Sensitive Click-Based Action",
               "type": "variant",
               "priority": 4
+            },
+            {
+              "id": "form_input",
+              "name": "Form Input",
+              "type": "variant",
+              "priority": 5
             },
             {
               "id": "non_sensitive_action",


### PR DESCRIPTION
**Issue**: Resolves #179 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: [AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: Inherited from parent [CWE-451](https://cwe.mitre.org/data/definitions/451.html)

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**:
"1. Use the `X-Frame-Options: DENY` HTTP response header on pages with sensitive information, to disallow framing of the page on external resources.
2. In the case where `DENY` is not an option, use `X-Frame-Options: SAMEORIGIN`.
3. In the case where `SAMEORIGIN` is not an option, `X-Frame-Options: ALLOW-FROM https://example.com/`"
