### PR TITLE
Revise Subdomain Takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - cross_site_scripting_xss.stored.privileged_user_to_privilege_elevation
 - cross_site_scripting_xss.stored.privileged_user_to_no_privilege_elevation
 - server_security_misconfiguration.clickjacking.form_input
+- server_security_misconfiguration.misconfigured_dns.basic_subdomain_takeover
+- server_security_misconfiguration.misconfigured_dns.high_impact_subdomain_takeover
 
 ### Removed
 - server_security_misconfiguration.mail_server_misconfiguration.missing_spf_on_email_domain
 - server_security_misconfiguration.mail_server_misconfiguration.email_spoofable_via_third_party_api_misconfiguration
 - cross_site_scripting_xss.stored.admin_to_anyone
+- server_security_misconfiguration.misconfigured_dns.subdomain_takeover
 
 ### Changed
 - broken_authentication_and_session_management.failure_to_invalidate_session.on_password_change updated remediation advice

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -97,5 +97,8 @@
   },
   "cross_site_scripting_xss.stored.admin_to_anyone": {
     "1.5": "cross_site_scripting_xss.stored.privileged_user_to_privilege_elevation"
+  },
+  "server_security_misconfiguration.misconfigured_dns.subdomain_takeover": {
+    "1.5": "server_security_misconfiguration.misconfigured_dns.basic_subdomain_takeover"
   }
 }

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -43,7 +43,11 @@
           "id": "misconfigured_dns",
           "children": [
             {
-              "id": "subdomain_takeover",
+              "id": "basic_subdomain_takeover",
+              "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
+            },
+            {
+              "id": "high_impact_subdomain_takeover",
               "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N"
             },
             {

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -64,7 +64,14 @@
           "id": "misconfigured_dns",
           "children": [
             {
-              "id": "subdomain_takeover",
+              "id": "basic_subdomain_takeover",
+              "remediation_advice": "1. Set up your external service so it fully listens to your wildcard DNS.\n2. Keep your DNS-entries constantly vetted and restricted.",
+              "references": [
+                "https://labs.detectify.com/2014/10/21/hostile-subdomain-takeover-using-herokugithubdesk-more/"
+              ]
+            },
+            {
+              "id": "high_impact_subdomain_takeover",
               "remediation_advice": "1. Set up your external service so it fully listens to your wildcard DNS.\n2. Keep your DNS-entries constantly vetted and restricted.",
               "references": [
                 "https://labs.detectify.com/2014/10/21/hostile-subdomain-takeover-using-herokugithubdesk-more/"

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -63,8 +63,14 @@
           "type": "subcategory",
           "children": [
             {
-              "id": "subdomain_takeover",
-              "name": "Subdomain Takeover",
+              "id": "basic_subdomain_takeover",
+              "name": "Basic Subdomain Takeover",
+              "type": "variant",
+              "priority": 3
+            },
+            {
+              "id": "high_impact_subdomain_takeover",
+              "name": "High Impact Subdomain Takeover",
               "type": "variant",
               "priority": 2
             },


### PR DESCRIPTION
**Issue**: Resolves #183 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**:
-`basic_subdomain_takeover`: [AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N)
-`high_impact_subdomain_takeover`: [AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: Inherited from parent `server_security_misconfiguration` [CWE-16](https://cwe.mitre.org/data/definitions/16.html)

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**: No change from the previously existing advice
"1. Set up your external service so it fully listens to your wildcard DNS.
2. Keep your DNS-entries constantly vetted and restricted."
https://labs.detectify.com/2014/10/21/hostile-subdomain-takeover-using-herokugithubdesk-more/

**[Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json)**: `server_security_misconfiguration.misconfigured_dns.subdomain_takeover` will map to `server_security_misconfiguration.misconfigured_dns.basic_subdomain_takeover`
