### PR TITLE
Add Password Reset Token Leakage via Host Header Poisoning on Password Reset Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+- sensitive_data_exposure.weak_password_reset_implementation.token_leakage_via_host_header_poisoning
 
 ### Removed
 

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -451,7 +451,13 @@
         },
         {
           "id": "weak_password_reset_implementation",
-          "cvss_v3": "AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N"
+          "cvss_v3": "AV:N/AC:H/PR:L/UI:R/S:U/C:H/I:N/A:N",
+          "children": [
+            {
+              "id": "token_leakage_via_host_header_poisoning",
+              "cvss_v3": "AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:L"
+            }
+          ]
         },
         {
           "id": "mixed_content",

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -750,6 +750,13 @@
             {
               "id": "password_reset_token_sent_over_http",
               "remediation_advice": "Avoid sending a password reset token over `HTTP`. A password reset token must always be transmitted via `HTTPS`."
+            },
+            {
+              "id": "token_leakage_via_host_header_poisoning",
+              "remediation_advice": "If the web application makes use of the host header value when composing the reset link, an attacker can poison the password reset link that is sent to a victim. If the victim clicks on the poisoned reset link in the email, the attacker will obtain the password reset token and can go ahead and reset the victim’s password. To protect your systems from this type of attack never trust the host header as it is controlled by the users.",
+              "references": [
+                "https://www.acunetix.com/blog/articles/automated-detection-of-host-header-attacks/"
+              ]
             }
           ]
         },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -903,6 +903,12 @@
               "name": "Password Reset Token Sent Over HTTP",
               "type": "variant",
               "priority": 4
+            },
+            {
+              "id": "token_leakage_via_host_header_poisoning",
+              "name": "Token Leakage via Host Header Poisoning",
+              "type": "variant",
+              "priority": 2
             }
           ]
         },


### PR DESCRIPTION
**Issue**: Resolves #199 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: [AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:L](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:L)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: Inherited from parent [CWE-640](https://cwe.mitre.org/data/definitions/640.html)

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**:
"If the web application makes use of the host header value when composing the reset link, an attacker can poison the password reset link that is sent to a victim. If the victim clicks on the poisoned reset link in the email, the attacker will obtain the password reset token and can go ahead and reset the victim’s password. To protect your systems from this type of attack never trust the host header as it is controlled by the users.",
https://www.acunetix.com/blog/articles/automated-detection-of-host-header-attacks/
