### PR TITLE
Add email spoofing on non-email domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Added
 - sensitive_data_exposure.weak_password_reset_implementation.token_leakage_via_host_header_poisoning
+- server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_non_email_domain
 
 ### Removed
 

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -131,6 +131,15 @@
                 "http://www.openspf.org/SPF_Record_Syntax",
                 "http://www.openspf.org/FAQ/Common_mistakes#include"
               ]
+            },
+            {
+              "id": "email_spoofing_on_non_email_domain",
+              "remediation_advice": "Consider adding email spoofing protections for all your domains as attackers may resort to spoofing those, regardless of whether emails originate from them or not. Victims can still be fooled by seeing your domain.",
+              "references": [
+                "https://mxtoolbox.com/DMARCRecordGenerator.aspx",
+                "https://dmarc.org/2016/03/best-practices-for-email-senders/",
+                "https://www.ftc.gov/system/files/documents/reports/businesses-can-help-stop-phishing-protect-their-brands-using-email-authentication-ftc-staff/email_authentication_staff_perspective.pdf"
+              ]
             }
           ]
         },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -116,6 +116,12 @@
               "name": "Missing or Misconfigured SPF and/or DKIM",
               "type": "variant",
               "priority": 5
+            },
+            {
+              "id": "email_spoofing_on_non_email_domain",
+              "name": "Email Spoofing on non-email domain",
+              "type": "variant",
+              "priority": 5
             }
           ]
         },


### PR DESCRIPTION
**Issue**: Resolves #204

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: Inherited from parent [AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: Inherited from parent [CWE-16](https://cwe.mitre.org/data/definitions/16.html)

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**:
"Consider adding email spoofing protections for all your domains as attackers may resort to spoofing those, regardless of whether emails originate from them or not. Victims can still be fooled by seeing your domain.",
https://mxtoolbox.com/DMARCRecordGenerator.aspx
https://dmarc.org/2016/03/best-practices-for-email-senders/
https://www.ftc.gov/system/files/documents/reports/businesses-can-help-stop-phishing-protect-their-brands-using-email-authentication-ftc-staff/email_authentication_staff_perspective.pdf
