### PR TITLE
Add 2FA secret related entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - sensitive_data_exposure.weak_password_reset_implementation.token_leakage_via_host_header_poisoning
 - server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_non_email_domain
 - broken_access_control.username_enumeration.non_brute_force
+- insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_cannot_be_rotated
+- insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled
 
 ### Removed
 - broken_access_control.username_enumeration.data_leak

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -674,6 +674,19 @@
               "cvss_v3": "AV:N/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:N"
             }
           ]
+        },
+        {
+          "id": "weak_2fa_implementation",
+          "children": [
+            {
+              "id": "two_fa_secret_cannot_be_rotated",
+              "cvss_v3": "AV:P/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+            },
+            {
+              "id": "two_fa_secret_remains_obtainable_after_two_fa_is_enabled",
+              "cvss_v3": "AV:P/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
+            }
+          ]
         }
       ]
     },

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -1031,7 +1031,7 @@
         },
         {
           "id": "weak_2fa_implementation",
-          "remediation_advice": "Ensure that the second factor authentication is properly configured and cannot be bypassed. Add a 2FA failsafe mechanism so the users can safely recover their accounts."
+          "remediation_advice": "Ensure that the second factor authentication is properly configured and cannot be bypassed. 2FA secret should be rotated every time 2FA is reenabled by the user and not remain obtainable after 2FA is turned on. Additionally consider providing a 2FA failsafe mechanism so the users can safely recover their accounts."
         }
       ]
     },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1468,6 +1468,18 @@
           "type": "subcategory",
           "children": [
             {
+              "id": "two_fa_secret_cannot_be_rotated",
+              "name": "2FA Secret Cannot be Rotated",
+              "type": "variant",
+              "priority": 4
+            },
+            {
+              "id": "two_fa_secret_remains_obtainable_after_two_fa_is_enabled",
+              "name": "2FA Secret Remains Obtainable After 2FA is Enabled",
+              "type": "variant",
+              "priority": 4
+            },
+            {
               "id": "missing_failsafe",
               "name": "Missing Failsafe",
               "type": "variant",


### PR DESCRIPTION
**Issue**: Resolves #203 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: [AV:P/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:P/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: N/A (inherited from the category)

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**:
"Ensure that the second factor authentication is properly configured and cannot be bypassed. 2FA secret should be rotated every time 2FA is reenabled by the user and not remain obtainable after 2FA is turned on. Additionally consider providing a 2FA failsafe mechanism so the users can safely recover their accounts."