### PR TITLE
Enforce uniformity in id's by disallowing numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - broken_access_control.username_enumeration.non_brute_force
 - insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_cannot_be_rotated
 - insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled
+- insufficient_security_configurability.weak_two_fa_implementation
+- sensitive_data_exposure.token_leakage_via_referer.trusted_third_party
+- sensitive_data_exposure.token_leakage_via_referer.untrusted_third_party
+- cross_site_scripting_xss.ie_only.ie_eleven
+- cross_site_scripting_xss.ie_only.older_version_ie_eleven
+- insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_cannot_be_rotated
+- insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled
 
 ### Removed
 - broken_access_control.username_enumeration.data_leak
+- insufficient_security_configurability.weak_2fa_implementation
+- sensitive_data_exposure.token_leakage_via_referer.trusted_3rd_party
+- sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party
+- cross_site_scripting_xss.ie_only.ie11
+- cross_site_scripting_xss.ie_only.older_version_ie11
+- insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_cannot_be_rotated
+- insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled
 
 ### Changed
 - server_security_misconfiguration.username_enumeration name changed from "Username Enumeration" to "Username/Email Enumeration"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - sensitive_data_exposure.weak_password_reset_implementation.token_leakage_via_host_header_poisoning
 - server_security_misconfiguration.mail_server_misconfiguration.email_spoofing_on_non_email_domain
 - broken_access_control.username_enumeration.non_brute_force
-- insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_cannot_be_rotated
-- insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled
+- insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_cannot_be_rotated
+- insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled
 - insufficient_security_configurability.weak_two_fa_implementation
 - sensitive_data_exposure.token_leakage_via_referer.trusted_third_party
 - sensitive_data_exposure.token_leakage_via_referer.untrusted_third_party
 - cross_site_scripting_xss.ie_only.ie_eleven
 - cross_site_scripting_xss.ie_only.older_version_ie_eleven
-- insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_cannot_be_rotated
-- insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled
 
 ### Removed
 - broken_access_control.username_enumeration.data_leak
@@ -25,8 +23,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party
 - cross_site_scripting_xss.ie_only.ie11
 - cross_site_scripting_xss.ie_only.older_version_ie11
-- insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_cannot_be_rotated
-- insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled
 
 ### Changed
 - server_security_misconfiguration.username_enumeration name changed from "Username Enumeration" to "Username/Email Enumeration"

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -145,5 +145,11 @@
   },
   "cross_site_scripting_xss.ie_only.older_version_ie11": {
     "1.7": "cross_site_scripting_xss.ie_only.older_version_ie_eleven"
+  },
+  "insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_cannot_be_rotated": {
+    "1.7": "insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_cannot_be_rotated"
+  },
+  "insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled": {
+    "1.7": "insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled"
   }
 }

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -145,11 +145,5 @@
   },
   "cross_site_scripting_xss.ie_only.older_version_ie11": {
     "1.7": "cross_site_scripting_xss.ie_only.older_version_ie_eleven"
-  },
-  "insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_cannot_be_rotated": {
-    "1.7": "insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_cannot_be_rotated"
-  },
-  "insufficient_security_configurability.weak_2fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled": {
-    "1.7": "insufficient_security_configurability.weak_two_fa_implementation.two_fa_secret_remains_obtainable_after_two_fa_is_enabled"
   }
 }

--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -130,5 +130,20 @@
   },
   "broken_access_control.username_enumeration.data_leak": {
     "1.7": "broken_access_control.username_enumeration.non_brute_force"
+  },
+  "insufficient_security_configurability.weak_2fa_implementation": {
+    "1.7": "insufficient_security_configurability.weak_two_fa_implementation"
+  },
+  "sensitive_data_exposure.token_leakage_via_referer.trusted_3rd_party": {
+    "1.7": "sensitive_data_exposure.token_leakage_via_referer.trusted_third_party"
+  },
+  "sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party": {
+    "1.7": "sensitive_data_exposure.token_leakage_via_referer.untrusted_third_party"
+  },
+  "cross_site_scripting_xss.ie_only.ie11": {
+    "1.7": "cross_site_scripting_xss.ie_only.ie_eleven"
+  },
+  "cross_site_scripting_xss.ie_only.older_version_ie11": {
+    "1.7": "cross_site_scripting_xss.ie_only.older_version_ie_eleven"
   }
 }

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -428,11 +428,11 @@
           "id": "token_leakage_via_referer",
           "children": [
             {
-              "id": "trusted_3rd_party",
+              "id": "trusted_third_party",
               "cvss_v3": "AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:N/A:N"
             },
             {
-              "id": "untrusted_3rd_party",
+              "id": "untrusted_third_party",
               "cvss_v3": "AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:N"
             },
             {
@@ -534,7 +534,7 @@
           "id": "ie_only",
           "children": [
             {
-              "id": "ie11",
+              "id": "ie_eleven",
               "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
             },
             {
@@ -542,7 +542,7 @@
               "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
             },
             {
-              "id": "older_version_ie11",
+              "id": "older_version_ie_eleven",
               "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N"
             }
           ]

--- a/mappings/cvss_v3.json
+++ b/mappings/cvss_v3.json
@@ -676,7 +676,7 @@
           ]
         },
         {
-          "id": "weak_2fa_implementation",
+          "id": "weak_two_fa_implementation",
           "children": [
             {
               "id": "two_fa_secret_cannot_be_rotated",

--- a/mappings/cvss_v3.schema.json
+++ b/mappings/cvss_v3.schema.json
@@ -10,7 +10,7 @@
       },
       "required": ["default"]
     },
-    "VRTid": { "type": "string", "pattern": "^[a-z_][a-z_0-9]*$" },
+    "VRTid": { "type": "string", "pattern": "^[a-z_]*$" },
     "CVSSv3": { "type": "string", "pattern": "^AV:[NALP]/AC:[LH]/PR:[NLH]/UI:[NR]/S:[UC]/C:[NLH]/I:[NLH]/A:[NLH]$" },
     "Mapping": {
       "type": "object",

--- a/mappings/cwe.schema.json
+++ b/mappings/cwe.schema.json
@@ -10,7 +10,7 @@
       },
       "required": ["default"]
     },
-    "VRTid": { "type": "string", "pattern": "^[a-z_][a-z_0-9]*$" },
+    "VRTid": { "type": "string", "pattern": "^[a-z_]*$" },
     "CWE": { "type" : [ "array", "null" ],
       "items" : { "type": "string", "pattern": "^CWE-[0-9]*$" },
       "minItems": 1,

--- a/mappings/remediation_advice.json
+++ b/mappings/remediation_advice.json
@@ -1030,7 +1030,7 @@
           ]
         },
         {
-          "id": "weak_2fa_implementation",
+          "id": "weak_two_fa_implementation",
           "remediation_advice": "Ensure that the second factor authentication is properly configured and cannot be bypassed. 2FA secret should be rotated every time 2FA is reenabled by the user and not remain obtainable after 2FA is turned on. Additionally consider providing a 2FA failsafe mechanism so the users can safely recover their accounts."
         }
       ]

--- a/mappings/remediation_advice.schema.json
+++ b/mappings/remediation_advice.schema.json
@@ -15,7 +15,7 @@
       },
       "required": ["default", "keys"]
     },
-    "VRTid": { "type": "string", "pattern": "^[a-z_][a-z_0-9]*$" },
+    "VRTid": { "type": "string", "pattern": "^[a-z_]*$" },
     "RemediationAdvice": { "type": "string" },
     "References": { "type" : "array",
       "items" : { "type": "string", "pattern": "^http[s]?:\/\/.*$" },

--- a/vrt.schema.json
+++ b/vrt.schema.json
@@ -12,7 +12,7 @@
       "VRT": {
         "type": "object",
         "properties": {
-          "id":             { "type": "string", "pattern": "^[a-z_][a-z_0-9]*$" },
+          "id":             { "type": "string", "pattern": "^[a-z_]*$" },
           "type":           { "type": "string", "enum": [ "category", "subcategory", "variant" ] },
           "name":           { "type": "string", "pattern": "^[ a-zA-Z0-9-+()\/,.<]*$" },
           "priority":       {
@@ -27,7 +27,7 @@
       "VRTparent": {
         "type": "object",
         "properties": {
-          "id":             { "type": "string", "pattern": "^[a-z_][a-z_0-9]*$" },
+          "id":             { "type": "string", "pattern": "^[a-z_]*$" },
           "name":           { "type": "string", "pattern": "^[ a-zA-Z0-9-+()\/,.<]*$" },
           "type":           { "type": "string", "enum": [ "category", "subcategory" ] },
           "children": {

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -849,13 +849,13 @@
           "type": "subcategory",
           "children": [
             {
-              "id": "trusted_3rd_party",
+              "id": "trusted_third_party",
               "name": "Trusted 3rd Party",
               "type": "variant",
               "priority": 5
             },
             {
-              "id": "untrusted_3rd_party",
+              "id": "untrusted_third_party",
               "name": "Untrusted 3rd Party",
               "type": "variant",
               "priority": 4
@@ -1042,7 +1042,7 @@
           "type": "subcategory",
           "children": [
             {
-              "id": "ie11",
+              "id": "ie_eleven",
               "name": "IE11",
               "type": "variant",
               "priority": 4
@@ -1054,7 +1054,7 @@
               "priority": 5
             },
             {
-              "id": "older_version_ie11",
+              "id": "older_version_ie_eleven",
               "name": "Older Version (< IE11)",
               "type": "variant",
               "priority": 5
@@ -1463,7 +1463,7 @@
           ]
         },
         {
-          "id": "weak_2fa_implementation",
+          "id": "weak_two_fa_implementation",
           "name": "Weak 2FA Implementation",
           "type": "subcategory",
           "children": [


### PR DESCRIPTION
**Issue**: Resolves #216

Only allowing numbers in the front of an id means that some things end up being represented as both a number and the spelled out version.  Operations team has decided to go with enforcing a more strict json schema to enforce uniformity.

This will avoid strange situations like this:
<img width="627" alt="screen shot 2019-02-12 at 11 52 28 am" src="https://user-images.githubusercontent.com/1854876/52663952-b8c29500-2ebc-11e9-98be-a31c54632300.png">

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: no change

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: no change

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**: no change

**[Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json)**:
`insufficient_security_configurability.weak_2fa_implementation` will map to `insufficient_security_configurability.weak_two_fa_implementation`
`sensitive_data_exposure.token_leakage_via_referer.trusted_3rd_party` will map to `sensitive_data_exposure.token_leakage_via_referer.trusted_third_party`
`sensitive_data_exposure.token_leakage_via_referer.untrusted_3rd_party` will map to `sensitive_data_exposure.token_leakage_via_referer.untrusted_third_party`
`cross_site_scripting_xss.ie_only.ie11` will map to `cross_site_scripting_xss.ie_only.ie_eleven`
`cross_site_scripting_xss.ie_only.older_version_ie11` will map to `cross_site_scripting_xss.ie_only.older_version_ie_eleven`