### PR TITLE
fix buildkite builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.6
-
+ENV PYTHONDONTWRITEBYTECODE="1"
 RUN pip install jsonschema GitPython semantic_version
 
 WORKDIR /tmp/vrt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6
-ENV PYTHONDONTWRITEBYTECODE="1"
+
 RUN pip install jsonschema GitPython semantic_version
 
 WORKDIR /tmp/vrt
-CMD [ "python3" , "./validate_vrt.py" ]
+CMD [ "python3", "-B" , "./validate_vrt.py" ]


### PR DESCRIPTION
Attempt to prevent buildkite failures by not writing pyc files that do not get deleted

Currently most of our builds in buildkite fail because the initial step of cloning the repository fails because the working directory is not empty.

The working directory fails to be emptied because the contents is owned by root so the buildkite agent user is unable to delete the files within.

After some investigation with @tessereth , the only files that are there are the generated .pyc files.  Setting this ENV var should prohibit docker from generating these files when running the tests.

python docs: https://docs.python.org/3/using/cmdline.html#envvar-PYTHONDONTWRITEBYTECODE