### PR TITLE
add Email Hyperlink Injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - sensitive_data_exposure.token_leakage_via_referer.untrusted_third_party
 - cross_site_scripting_xss.ie_only.ie_eleven
 - cross_site_scripting_xss.ie_only.older_version_ie_eleven
+- server_side_injection.content_spoofing.email_hyperlink_injection_based_on_email_provider
 
 ### Removed
 - broken_access_control.username_enumeration.data_leak

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -590,6 +590,13 @@
               ]
             },
             {
+              "id": "email_hyperlink_injection_based_on_email_provider",
+              "remediation_advice": "Always ensure that email contents cannot be tampered with. Limit what the user can insert into the email by filtering special characters and limiting the amount of characters that can be inserted. Filter out any URLs as they are often rendered as links by email providers.",
+              "references": [
+                "https://www.owasp.org/index.php/Input_Validation_Cheat_Sheet"
+              ]
+            },
+            {
               "id": "text_injection",
               "remediation_advice": "As a best practice, handle dynamic text input and use a whitelist of proper inputs."
             },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -599,6 +599,12 @@
               "priority": 4
             },
             {
+              "id": "email_hyperlink_injection_based_on_email_provider",
+              "name": "Email Hyperlink Injection Based on Email Provider",
+              "type": "variant",
+              "priority": 5
+            },
+            {
               "id": "text_injection",
               "name": "Text Injection",
               "type": "variant",


### PR DESCRIPTION
**Issue**: Resolves #217 

**[CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3.json)**: Inherited from parent [AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:N)

**[CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe.json)**: Inherited from parent [CWE-929](https://cwe.mitre.org/data/definitions/929.html)

**[Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice.json)**:
"Always ensure that email contents cannot be tampered with. Limit what the user can insert into the email by filtering special characters and limiting the amount of characters that can be inserted. Filter out any URLs as they are often rendered as links by email providers."
-https://www.owasp.org/index.php/Input_Validation_Cheat_Sheet
