### PR TITLE
Add Automotive Security Misconfiguration mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+- Remediation Advice and CVSS mappings for automotive_security_misconfiguration
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ This would map the `other` category and any unknown IDs to the `metadata.default
 All VRT IDs nested below `server_side_injection` would map to `red`, except for
 `server_side_injection.content_spoofing.iframe_injection` which would map to `yellow`.
 
+Each mapping should be setup in the following structure:
+
+    .
+    ├── ...
+    ├── mappings
+    │   ├── new_mapping
+    |   |     ├── new_mapping.schema.json # Following JSON Schema (https://json-schema.org/), to be run in CI
+    |   |     ├── new_mapping.json        # Actual VRT mapping file as described above
+    │   └── ...              
+    └── ...
+
 #### Supported Mappings
 - [CVSS v3](mappings/cvss_v3/cvss_v3.json)
 - [CWE](mappings/cwe/cwe.json)

--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -845,15 +845,82 @@
       "children": [
         {
           "id": "infotainment",
-          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
+          "children": [
+            {
+              "id": "pii_leakage",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+            },
+            {
+              "id": "code_execution_can_bus_pivot",
+              "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+            },
+            {
+              "id": "code_execution_no_can_bus_pivot",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:L/A:L"
+            },
+            {
+              "id": "unauthorized_access_to_services",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:N/S:C/C:L/I:L/A:L"
+            },
+            {
+              "id": "source_code_dump",
+              "cvss_v3": "AV:P/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L"
+            },
+            {
+              "id": "dos_brick",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L"
+            },
+            {
+              "id": "default_credentials",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
+            }
+          ]
         },
         {
           "id": "rf_hub",
-          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
+          "children": [
+            {
+              "id": "key_fob_cloning",
+              "cvss_v3": "AV:A/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+            },
+            {
+              "id": "can_injection_interaction",
+              "cvss_v3": "AV:P/AC:H/PR:N/UI:N/S:U/C:L/I:N/A:N"
+            },
+            {
+              "id": "data_leakage_pull_encryption_mechanism",
+              "cvss_v3": "AV:A/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L"
+            },
+            {
+              "id": "unauthorized_access_turn_on",
+              "cvss_v3": "AV:A/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:L"
+            },
+            {
+              "id": "roll_jam",
+              "cvss_v3": "AV:A/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:N"
+            },
+            {
+              "id": "replay",
+              "cvss_v3": "AV:A/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:N"
+            },
+            {
+              "id": "relay",
+              "cvss_v3": "AV:A/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:N"
+            }
+          ]
         },
         {
           "id": "can",
-          "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
+          "children": [
+            {
+              "id": "injection_disallowed_messages",
+              "cvss_v3": "AV:P/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+            },
+            {
+              "id": "injection_dos",
+              "cvss_v3": "AV:P/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+            }
+          ]
         }
       ]
     },

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -1214,15 +1214,142 @@
       "children": [
         {
           "id": "infotainment",
-          "remediation_advice": ""
+          "children": [
+            {
+              "id": "pii_leakage",
+              "remediation_advice": "Do not store PII such as call logs, text messages, and contact lists or names as plaintext in the infotainment system.",
+              "references": [
+                "https://www.prnewswire.com/news-releases/carsblues-vehicle-hack-exploits-vehicle-infotainment-systems-allowing-access-to-call-logs-text-messages-and-more-300751244.html"
+              ]
+            },
+            {
+              "id": "code_execution_can_bus_pivot",
+              "remediation_advice": "Filter arbitrary commands and apply input validation to any media devices to prevent executing from the infotainment system. Make sure that the infotainment system is on a sandbox module and does not have direct interaction to the CANbus network.",
+              "references": [
+                "https://motherboard.vice.com/en_us/article/3kvw8y/researchers-hack-car-infotainment-system-and-find-sensitive-user-data-inside",
+                "https://www.bleepingcomputer.com/news/security/you-can-hack-some-mazda-cars-with-a-usb-flash-drive/",
+                "http://illmatics.com/carhacking.html"
+              ]
+            },
+            {
+              "id": "code_execution_no_can_bus_pivot",
+              "remediation_advice": "Filter arbitrary commands and apply input validation to any media devices to prevent executing from the infotainment system.",
+              "references": [
+                "https://motherboard.vice.com/en_us/article/3kvw8y/researchers-hack-car-infotainment-system-and-find-sensitive-user-data-inside",
+                "https://www.bleepingcomputer.com/news/security/you-can-hack-some-mazda-cars-with-a-usb-flash-drive/",
+                "http://illmatics.com/carhacking.html"
+              ]
+            },
+            {
+              "id": "unauthorized_access_to_services",
+              "remediation_advice": "Filter services that allow you to control the vehicle or infotainment system from being accessed by unauthorized users. Apply authentication mechanisms to certain endpoints.",
+              "references": [
+                "https://www.troyhunt.com/controlling-vehicle-features-of-nissan/"
+              ]
+            },
+            {
+              "id": "source_code_dump",
+              "remediation_advice": "Obfuscate the code and find creative ways to break disassemblers and debuggers.",
+              "references": [
+                "https://en.wikipedia.org/wiki/Security_through_obscurity",
+                "https://www.researchgate.net/publication/320859156_Source_Code_Vulnerabilities_in_IoT_Software_Systems"
+              ]
+            },
+            {
+              "id": "dos_brick",
+              "remediation_advice": "Filter malicious payloads or string attacks. Apply rate limiting on the app level side.",
+              "references": [
+                "https://www.owasp.org/index.php/Application_Denial_of_Service",
+                "https://www.forbes.com/sites/leemathews/2017/04/10/a-malware-outbreak-is-bricking-insecure-iot-devices/#36603e4a29a3",
+                "https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Denial_of_Service_Cheat_Sheet.md"
+              ]
+            },
+            {
+              "id": "default_credentials",
+              "remediation_advice": "Do not ship infotainment systems with any configured accounts or with default and common usernames and passwords. Do not hard code any backdoor accounts or special access mechanisms.",
+              "references": [
+                "https://www.owasp.org/index.php/Testing_for_default_credentials_(OTG-AUTHN-002)",
+                "https://www.owasp.org/index.php/Configuration#Default_passwords"
+              ]
+            }
+          ]
         },
         {
           "id": "rf_hub",
-          "remediation_advice": ""
+          "children": [
+            {
+              "id": "key_fob_cloning",
+              "remediation_advice": "Implement key fob encryption.",
+              "references": [
+                "https://electronics.howstuffworks.com/gadgets/automotive/unlock-car-door-remote1.htm",
+                "https://www.wired.com/story/hackers-steal-tesla-model-s-seconds-key-fob/"
+              ]
+            },
+            {
+              "id": "can_injection_interaction",
+              "remediation_advice": "Implement a secure gateway that prevents CAN Injection from the RF Hub.",
+              "references": [
+                "https://www.reddit.com/r/CarHacking/comments/73qs0x/chrysler_sgw_security_gateway/"
+              ]
+            },
+            {
+              "id": "data_leakage_pull_encryption_mechanism",
+              "remediation_advice": "Inspect outgoing traffic from the RF Hub and make sure encryption mechanism cannot be extracted.",
+              "references": [
+                "https://www.networkworld.com/article/2284289/data-leak-prevention-and-encryption--tools-that-can-work-together.html"
+              ]
+            },
+            {
+              "id": "unauthorized_access_turn_on",
+              "remediation_advice": "",
+              "references": [
+                ""
+              ]
+            },
+            {
+              "id": "roll_jam",
+              "remediation_advice": "Update how rolling codes work in vehicles and do over-the-air update capabilities.",
+              "references": [
+                "https://makezine.com/2015/08/11/anatomy-of-the-rolljam-wireless-car-hack/"
+              ]
+            },
+            {
+              "id": "replay",
+              "remediation_advice": "Block the transmission of unwanted radio signals and block all forms of the amplification attacks.",
+              "references": [
+                "https://www.wired.com/2017/04/just-pair-11-radio-gadgets-can-steal-car/",
+                "https://www.wired.com/2016/03/study-finds-24-car-models-open-unlocking-ignition-hack/"
+              ]
+            },
+            {
+              "id": "relay",
+              "remediation_advice": "Block the transmission of unwanted radio signals and block all forms of the amplification attacks.",
+              "references": [
+                "https://www.wired.com/2017/04/just-pair-11-radio-gadgets-can-steal-car/",
+                "https://www.wired.com/2016/03/study-finds-24-car-models-open-unlocking-ignition-hack/"
+              ]
+            }
+          ]
         },
         {
           "id": "can",
-          "remediation_advice": ""
+          "children": [
+            {
+              "id": "injection_disallowed_messages",
+              "remediation_advice": "Filter malicious CANbus requests or codes especially if not included in the DBC file by implementing a secure gateway.",
+              "references": [
+                "https://news.voyage.auto/an-introduction-to-the-can-bus-how-to-programmatically-control-a-car-f1b18be4f377"
+              ]
+            },
+            {
+              "id": "injection_dos",
+              "remediation_advice": "Filter malicious CANbus requests or codes by implementing a secure gateway, as well as limit access to input ports (specifically OBD-II) on automobiles as pointed out by CERT.",
+              "references": [
+                "https://ics-cert.us-cert.gov/alerts/ICS-ALERT-17-209-01",
+                "http://www.autoconnectedcar.com/2017/08/connect-car-can-bus-cant-handle-dos-hacksattacks-researchers-report-can-standard-can-be-changed/"
+              ]
+            }
+          ]
         }
       ]
     }

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -1301,10 +1301,7 @@
             },
             {
               "id": "unauthorized_access_turn_on",
-              "remediation_advice": "",
-              "references": [
-                ""
-              ]
+              "remediation_advice": ""
             },
             {
               "id": "roll_jam",


### PR DESCRIPTION
#### Issue: Resolves #202

The purpose of this PR is to add mappings (remediation advice and CVSS) for the new Automotive Security Misconfiguration category. All feedback is welcome!
Currently rf_hub.unauthorized_access_turn_on remediation advice is missing as well as the entire CVSS mapping

#### Checklist:
- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
