### PR TITLE
Revert "Add Indicators of Compromise category"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
-- indicators_of_compromise
 
 ### Removed
 

--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -856,10 +856,6 @@
           "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
         }
       ]
-    },
-    {
-      "id": "indicators_of_compromise",
-      "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
     }
   ]
 }

--- a/mappings/cwe/cwe.json
+++ b/mappings/cwe/cwe.json
@@ -436,10 +436,6 @@
           "cwe": null
         }
       ]
-    },
-    {
-      "id": "indicators_of_compromise",
-      "cwe": null
     }
   ]
 }

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -1225,10 +1225,6 @@
           "remediation_advice": ""
         }
       ]
-    },
-    {
-      "id": "indicators_of_compromise",
-      "remediation_advice": ""
     }
   ]
 }

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1932,12 +1932,6 @@
           ]
         }
       ]
-    },
-    {
-      "id": "indicators_of_compromise",
-      "name": "Indicators of Compromise",
-      "type": "category",
-      "priority": null
     }
   ]
 }


### PR DESCRIPTION
Reverts bugcrowd/vulnerability-rating-taxonomy#239

We need to add the automotive mappings first to release as a patch.