### PR TITLE
Add Failure to Invalidate Session on 2FA Activation/Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_security_misconfiguration.race_condition
 - server_security_misconfiguration.cache_poisoning
 - indicators_of_compromise
+- broken_authentication_and_session_management.failure_to_invalidate_session.on_two_fa_activation_change
 
 ### Removed
 

--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -374,6 +374,10 @@
               "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N"
             },
             {
+              "id": "on_two_fa_activation_change",
+              "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N"
+            },
+            {
               "id": "long_timeout",
               "cvss_v3": "AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:N/A:N"
             }

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -711,6 +711,10 @@
               "remediation_advice": "As a best practice, consider invalidating all sessions upon email change."
             },
             {
+              "id": "on_two_fa_activation_change",
+              "remediation_advice": "As a best practice, consider invalidating all sessions upon 2FA activation or change."
+            },
+            {
               "id": "long_timeout",
               "remediation_advice": "As a best practice, consider invalidating sessions after a shorter period of time."
             }

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -759,6 +759,12 @@
               "priority": 5
             },
             {
+              "id": "on_two_fa_activation_change",
+              "name": "On 2FA Activation/Change",
+              "type": "variant",
+              "priority": 5
+            },
+            {
               "id": "long_timeout",
               "name": "Long Timeout",
               "type": "variant",


### PR DESCRIPTION
#### Issue: Resolves #257 

#### [CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3/cvss_v3.json): [AV:P/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:P/AC:L/PR:H/UI:N/S:U/C:L/I:N/A:N)

#### [CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe/cwe.json): N/A

#### [Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice/remediation_advice.json): "As a best practice, consider invalidating all sessions upon 2FA activation or change."

#### Checklist:

- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed