### PR TITLE
Add lack of rate limiting on current password when changing password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_side_injection.ssti.custom
 - sensitive_data_exposure.via_localstorage_sessionstorage.sensitive_token
 - sensitive_data_exposure.via_localstorage_sessionstorage.non_sensitive_token
+- server_security_misconfiguration.no_rate_limiting_on_form.change_password
 
 ### Removed
 - sensitive_data_exposure.critically_sensitive_data.password_disclosure

--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -100,6 +100,10 @@
             {
               "id": "login",
               "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
+            },
+            {
+              "id": "change_password",
+              "cvss_v3": "AV:P/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:L"
             }
           ]
         },

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -198,6 +198,10 @@
             {
               "id": "sms_triggering",
               "remediation_advice": "1. Use a `CAPTCHA` to limit SMS triggering requests.\n2. Use a rate limit per IP address to throttle the amount of SMS triggering requests that can be made in a certain amount of time."
+            },
+            {
+              "id": "change_password",
+              "remediation_advice": "1. Use a `CAPTCHA` to limit current password check requests sent when changing account password.\n2. Use a rate limit per IP address to throttle the amount of said requests that can be made in a certain amount of time."
             }
           ]
         },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -197,6 +197,12 @@
               "name": "SMS-Triggering",
               "type": "variant",
               "priority": 4
+            },
+            {
+              "id": "change_password",
+              "name": "Change Password",
+              "type": "variant",
+              "priority": 5
             }
           ]
         },


### PR DESCRIPTION
#### Issue: Resolves #279 

#### [CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3/cvss_v3.json): [AV:P/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:L](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:P/AC:L/PR:H/UI:N/S:U/C:N/I:L/A:L)

#### [CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe/cwe.json): [CWE-799](https://cwe.mitre.org/data/definitions/799.html) (Inherited from parent)

#### [Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice/remediation_advice.json): 
1. Use a `CAPTCHA` to limit current password check requests sent when changing account password.
2. Use a rate limit per IP address to throttle the amount of said requests that can be made in a certain amount of time.

#### Checklist:

- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
