### PR TITLE
Add Auto Backup Allowed by Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - server_side_injection.ssti.custom
 - sensitive_data_exposure.via_localstorage_sessionstorage.sensitive_token
 - sensitive_data_exposure.via_localstorage_sessionstorage.non_sensitive_token
+- mobile_security_misconfiguration.auto_backup_allowed_by_default
 
 ### Removed
 - sensitive_data_exposure.critically_sensitive_data.password_disclosure

--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -860,6 +860,10 @@
         {
           "id": "clipboard_enabled",
           "cvss_v3": "AV:L/AC:H/PR:N/UI:R/S:C/C:L/I:N/A:N"
+        },
+        {
+          "id": "auto_backup_allowed_by_default",
+          "cvss_v3": "AV:P/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N"
         }
       ]
     },

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -1225,6 +1225,13 @@
         {
           "id": "clipboard_enabled",
           "remediation_advice": "Ensure that copy/paste functionality is disabled on sensitive content like credit card numbers, social security numbers etc. as other apps on the same device can access data stored in clipboard.\nThe example below disables clipboard for the `textField` TextView in Android:\n```java\ntextField.setCustomSelectionActionModeCallback(new ActionMode.Callback() {\n  public boolean onCreateActionMode(ActionMode actionMode, Menu menu) {\n    return false;\n  }\n\n  public boolean onPrepareActionMode(ActionMode actionMode, Menu menu) {\n    return false;\n  }\n\n  public boolean onActionItemClicked(ActionMode actionMode, MenuItem item) {\n    return false;\n  }\n\n  public void onDestroyActionMode(ActionMode actionMode) {\n  }\n});\ntextField.setLongClickable(false);\ntextField.setTextIsSelectable(false);\n```\nThe example below disables clipboard for UITextField in iOS:\n```swift\noverride public func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {\n  if action == #selector(copy(_:)) || action == #selector(paste(_:)) {\n    return false\n  }\n  return true\n}\n```"
+        },
+        {
+          "id": "auto_backup_allowed_by_default",
+          "remediation_advice": "Consider disabling auto backup of any sensitive application data. In Android you can disable auto backup by setting `android:allowBackup` in your app manifest file to false.",
+          "references": [
+            "https://developer.android.com/guide/topics/data/autobackup"
+          ]
         }
       ]
     },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1841,6 +1841,12 @@
           "name": "Clipboard Enabled",
           "type": "subcategory",
           "priority": 5
+        },
+        {
+          "id": "auto_backup_allowed_by_default",
+          "name": "Auto Backup Allowed by Default",
+          "type": "subcategory",
+          "priority": 5
         }
       ]
     },


### PR DESCRIPTION
#### Issue: Resolves #282 

#### [CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3/cvss_v3.json): [AV:P/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:P/AC:L/PR:H/UI:N/S:U/C:H/I:N/A:N)

#### [CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe/cwe.json): [CWE-919](https://cwe.mitre.org/data/definitions/919.html) (Inherited from parent)

#### [Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice/remediation_advice.json):
Consider disabling auto backup of any sensitive application data. In Android you can disable auto backup by setting `android:allowBackup` in your app manifest file to false.
https://developer.android.com/guide/topics/data/autobackup

#### Checklist:

- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
