### PR TITLE
Add Flash Based CSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - mobile_security_misconfiguration.auto_backup_allowed_by_default
 - server_security_misconfiguration.no_rate_limiting_on_form.change_password
 - server_side_injection.content_spoofing.impersonation_via_broken_link_hijacking
+- cross_site_request_forgery_csrf.flash_based.high_impact
+- cross_site_request_forgery_csrf.flash_based.low_impact
 
 ### Removed
 - sensitive_data_exposure.critically_sensitive_data.password_disclosure

--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -681,6 +681,19 @@
         {
           "id": "csrf_token_not_unique_per_request",
           "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:N/A:N"
+        },
+        {
+          "id": "flash_based",
+          "children": [
+            {
+              "id": "high_impact",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:H/A:N"
+            },
+            {
+              "id": "low_impact",
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
+            }
+          ]
         }
       ]
     },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1302,6 +1302,25 @@
           "name": "CSRF Token Not Unique Per Request",
           "type": "subcategory",
           "priority": 5
+        },
+        {
+          "id": "flash_based",
+          "name": "Flash-Based",
+          "type": "subcategory",
+          "children": [
+            {
+              "id": "high_impact",
+              "name": "High Impact",
+              "type": "variant",
+              "priority": 4
+            },
+            {
+              "id": "low_impact",
+              "name": "Low Impact",
+              "type": "variant",
+              "priority": 5
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
#### Issue: Resolves #280 

#### [CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3/cvss_v3.json):
- High Impact Flash-based CSRF: [AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:H/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:H/A:N)
- Low Impact Flash-based CSRF: [AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N)

#### [CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe/cwe.json): Inherited from parent [CWE-352](https://cwe.mitre.org/data/definitions/352.html)

#### [Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice/remediation_advice.json): Inheriting the general CSRF remediation advice via parent node


#### Checklist:

- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
