### PR TITLE
Cut v1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+
+### Removed
+
+### Changed
+
+## [v1.9](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.8...v1.9) - 2020-05-22
+### Added
 - sensitive_data_exposure.disclosure_of_secrets.for_publicly_accessible_asset
 - sensitive_data_exposure.disclosure_of_secrets.for_internal_asset
 - sensitive_data_exposure.disclosure_of_secrets.pay_per_use_abuse

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "release_date": "2019-09-25T00:00:00+00:00"
+    "release_date": "2020-05-22T00:00:00+00:00"
   },
   "content": [
     {


### PR DESCRIPTION
Cuts the latest release of VRT with updates [visible here](https://github.com/bugcrowd/vulnerability-rating-taxonomy/compare/v1.8...v1.9).

Usage within [Bugcrowd](www.bugcrowd.com) is expected to be deployed the week of June 8th.