### PR TITLE
Add 2FA Code Invalidation Cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
+- insufficient_security_configurability.weak_two_fa_implementation.two_fa_code_is_not_updated_after_new_code_is_requested
+- insufficient_security_configurability.weak_two_fa_implementation.old_two_fa_code_is_not_invalidated_after_new_code_is_generated
 
 ### Removed
 

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -1078,7 +1078,7 @@
         },
         {
           "id": "weak_two_fa_implementation",
-          "remediation_advice": "Ensure that the second factor authentication is properly configured and cannot be bypassed. 2FA secret should be rotated every time 2FA is reenabled by the user and not remain obtainable after 2FA is turned on. Additionally consider providing a 2FA failsafe mechanism so the users can safely recover their accounts."
+          "remediation_advice": "Ensure that the second factor authentication is properly configured, has sufficient rate limiting, and cannot be bypassed. 2FA secret should be rotated every time 2FA is reenabled by the user and not remain obtainable after 2FA is turned on. Additionally consider providing a 2FA failsafe mechanism so the users can safely recover their accounts."
         }
       ]
     },

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1607,6 +1607,18 @@
               "name": "Missing Failsafe",
               "type": "variant",
               "priority": 5
+            },
+            {
+              "id": "two_fa_code_is_not_updated_after_new_code_is_requested",
+              "name": "2FA Code is Not Updated After New Code is Requested",
+              "type": "variant",
+              "priority": 5
+            },
+            {
+              "id": "old_two_fa_code_is_not_invalidated_after_new_code_is_generated",
+              "name": "Old 2FA Code is Not Invalidated After New Code is Generated",
+              "type": "variant",
+              "priority": 5
             }
           ]
         }


### PR DESCRIPTION
#### Issue: Resolves #289 

#### [CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3/cvss_v3.json): [AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N](https://www.first.org/cvss/calculator/3.0#CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N) (Inherited from the parent)

#### [CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe/cwe.json): N/A

#### [Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice/remediation_advice.json): Inherited from the parent
"Ensure that the second factor authentication is properly configured, has sufficient rate limiting, and cannot be bypassed. 2FA secret should be rotated every time 2FA is reenabled by the user and not remain obtainable after 2FA is turned on. Additionally consider providing a 2FA failsafe mechanism so the users can safely recover their accounts."

#### Checklist:

- [x] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed