### PR TITLE
update IE-Only XSS to be P5 due to deprecation of IE

### DIFF
--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1132,26 +1132,7 @@
           "id": "ie_only",
           "name": "IE-Only",
           "type": "subcategory",
-          "children": [
-            {
-              "id": "ie_eleven",
-              "name": "IE11",
-              "type": "variant",
-              "priority": 4
-            },
-            {
-              "id": "xss_filter_disabled",
-              "name": "XSS Filter Disabled",
-              "type": "variant",
-              "priority": 5
-            },
-            {
-              "id": "older_version_ie_eleven",
-              "name": "Older Version (< IE11)",
-              "type": "variant",
-              "priority": 5
-            }
-          ]
+          "priority": 5
         },
         {
           "id": "referer",


### PR DESCRIPTION
With IE support being removed from Microsoft services in mid-august ([source](https://techcommunity.microsoft.com/t5/microsoft-365-blog/microsoft-365-apps-say-farewell-to-internet-explorer-11-and/ba-p/1591666)) it seems time to decrease the priority of such findings.