### PR TITLE
Adding new IDOR variants

### DIFF
--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -632,27 +632,19 @@
           "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N",
           "children": [
             {
-              "id": "read_no_sensitive_information",
+              "id": "manipulate_no_sensitive_information",
               "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:N"
             },
             {
-              "id": "read_sensitive_data_information_guid",
+              "id": "manipulate_sensitive_data_information_guid",
               "cvss_v3": "AV:N/AC:H/PR:L/UI:N/S:C/C:L/I:N/A:N"
-            },
-            {
-              "id": "action_sensitive_data_information_guid",
-              "cvss_v3": "AV:N/AC:H/PR:L/UI:N/S:C/C:N/I:L/A:L"
-            },
-            {
-              "id": "read_pii_data_information_guid",
-              "cvss_v3": "AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N"
             },
             {
               "id": "read_sensitive_data_information_int",
               "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N"
             },
             {
-              "id": "action_sensitive_data_information_guid",
+              "id": "alter_sensitive_data_information_guid",
               "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:L"
             },
             {

--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -628,6 +628,40 @@
       "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
       "children": [
         {
+          "id": "idor",
+          "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N",
+          "children": [
+            {
+              "id": "read_no_sensitive_information",
+              "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:N/A:N"
+            },
+            {
+              "id": "read_sensitive_data_information_guid",
+              "cvss_v3": "AV:N/AC:H/PR:L/UI:N/S:C/C:L/I:N/A:N"
+            },
+            {
+              "id": "action_sensitive_data_information_guid",
+              "cvss_v3": "AV:N/AC:H/PR:L/UI:N/S:C/C:N/I:L/A:L"
+            },
+            {
+              "id": "read_pii_data_information_guid",
+              "cvss_v3": "AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:N/A:N"
+            },
+            {
+              "id": "read_sensitive_data_information_int",
+              "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:N/A:N"
+            },
+            {
+              "id": "action_sensitive_data_information_guid",
+              "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:L"
+            },
+            {
+              "id": "read_pii_data_information_int",
+              "cvss_v3": "AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N"
+            }
+          ]
+        },
+        {
           "id": "server_side_request_forgery_ssrf",
           "children": [
             {

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1198,44 +1198,32 @@
           "priority": 3,
           "children": [
             {
-              "id": "read_no_sensitive_information",
-              "name": "Read Non-Sensitive Information",
+              "id": "manipulate_no_sensitive_information",
+              "name": "Manipulate Non-Sensitive Information",
               "type": "variant",
               "priority": 5
             },
             {
-              "id": "read_sensitive_data_information_guid",
-              "name": "Read Sensitive Data - GUID/Complex Object Identifiers",
+              "id": "manipulate_sensitive_data_information_guid",
+              "name": "Manipulate Sensitive Information | GUID/Complex Object Identifiers",
               "type": "variant",
               "priority": 4
             },
             {
-              "id": "action_sensitive_data_information_guid",
-              "name": "Modify/Delete Sensitive Data - GUID/Complex Object Identifiers",
-              "type": "variant",
-              "priority": 3
-            },
-            {
-              "id": "read_pii_data_information_guid",
-              "name": "Read Personal Data (PII) - GUID/Complex Object Identifiers",
-              "type": "variant",
-              "priority": 2
-            },
-            {
               "id": "read_sensitive_data_information_int",
-              "name": "Read Sensitive Data - Iteratable Object Identifiers",
+              "name": "Read Sensitive Information | Iteratable Object Identifiers",
               "type": "variant",
               "priority": 3
             },
             {
-              "id": "action_sensitive_data_information_int",
-              "name": "Modify/Delete Sensitive Data - Iteratable Object Identifiers",
+              "id": "alter_sensitive_data_information_int",
+              "name": "Alter Sensitive Information | Iteratable Object Identifiers",
               "type": "variant",
               "priority": 2
             },
             {
               "id": "read_pii_data_information_int",
-              "name": "Read Personal Data (PII) - Iteratable Object Identifiers",
+              "name": "Read Sensitive Information (PII) | Iteratable Object Identifiers",
               "type": "variant",
               "priority": 1
             }

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1195,7 +1195,51 @@
           "id": "idor",
           "name": "Insecure Direct Object References (IDOR)",
           "type": "subcategory",
-          "priority": null
+          "priority": 3,
+          "children": [
+            {
+              "id": "read_no_sensitive_information",
+              "name": "Read Non-Sensitive Information",
+              "type": "variant",
+              "priority": 5
+            },
+            {
+              "id": "read_sensitive_data_information_guid",
+              "name": "Read Sensitive Data - GUID/Complex Object Identifiers",
+              "type": "variant",
+              "priority": 4
+            },
+            {
+              "id": "action_sensitive_data_information_guid",
+              "name": "Modify/Delete Sensitive Data - GUID/Complex Object Identifiers",
+              "type": "variant",
+              "priority": 3
+            },
+            {
+              "id": "read_pii_data_information_guid",
+              "name": "Read Personal Data (PII) - GUID/Complex Object Identifiers",
+              "type": "variant",
+              "priority": 2
+            },
+            {
+              "id": "read_sensitive_data_information_int",
+              "name": "Read Sensitive Data - Iteratable Object Identifiers",
+              "type": "variant",
+              "priority": 3
+            },
+            {
+              "id": "action_sensitive_data_information_int",
+              "name": "Modify/Delete Sensitive Data - Iteratable Object Identifiers",
+              "type": "variant",
+              "priority": 2
+            },
+            {
+              "id": "read_pii_data_information_int",
+              "name": "Read Personal Data (PII) - Iteratable Object Identifiers",
+              "type": "variant",
+              "priority": 1
+            }
+          ]
         },
         {
           "id": "server_side_request_forgery_ssrf",


### PR DESCRIPTION
This pull request adds additional variants in the IDOR subcategoy. It is time to get more precise definitions of IDOR flavors in the VRT. I know this is a highly debated subject, but here is what I propose. I believe this covers 90% of all cases :

IDOR - Defaults to P3
 - Read Non-Sensitive Information - P5
 - Read Sensitive Data - GUID/Complex Object Identifiers - P4
 - Modify/Delete Sensitive Data - GUID/Complex Object Identifiers - P3
 - Read Personal Data (PII) - GUID/Complex Object Identifiers - P2
 - Read Sensitive Data - Iteratable Object Identifiers - P3
 - Modify/Delete Sensitive Data - Iteratable Object Identifiers - P2
 - Read Personal Data (PII) - Iteratable Object Identifiers - P1

This way, all IDORs will at least get a priority set upfront, and won't end up at the discretion of the triage team entirely.

I strongly believe these new variants would better capture the impacts for the end clients and facilitate the researchers job to push submissions.