### PR TITLE
Deprecation of XSS on IE11

### DIFF
--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -590,20 +590,7 @@
         },
         {
           "id": "ie_only",
-          "children": [
-            {
-              "id": "ie_eleven",
-              "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
-            },
-            {
-              "id": "xss_filter_disabled",
-              "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N"
-            },
-            {
-              "id": "older_version_ie_eleven",
-              "cvss_v3": "AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:N"
-            }
-          ]
+          "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:C/C:L/I:L/A:N"
         },
         {
           "id": "referer",

--- a/mappings/remediation_advice/remediation_advice.json
+++ b/mappings/remediation_advice/remediation_advice.json
@@ -860,18 +860,6 @@
       ],
       "children": [
         {
-          "id": "ie_only",
-          "children": [
-            {
-              "id": "xss_filter_disabled",
-              "remediation_advice": "As a best practice do not disable the XSS filter by utilizing `X-XSS-Protection: 0` header.",
-              "references": [
-                "https://msdn.microsoft.com/en-us/library/dd565647(v=vs.85).aspx"
-              ]
-            }
-          ]
-        },
-        {
           "id": "trace_method",
           "remediation_advice": "As the TRACE method can be utilized to bypass certain protections, consider disabling the HTTP method TRACE.",
           "references": [

--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1132,26 +1132,7 @@
           "id": "ie_only",
           "name": "IE-Only",
           "type": "subcategory",
-          "children": [
-            {
-              "id": "ie_eleven",
-              "name": "IE11",
-              "type": "variant",
-              "priority": 4
-            },
-            {
-              "id": "xss_filter_disabled",
-              "name": "XSS Filter Disabled",
-              "type": "variant",
-              "priority": 5
-            },
-            {
-              "id": "older_version_ie_eleven",
-              "name": "Older Version (< IE11)",
-              "type": "variant",
-              "priority": 5
-            }
-          ]
+          "priority": 5
         },
         {
           "id": "referer",


### PR DESCRIPTION
REMOVE: P4 - Cross-Site Scripting (XSS) - IE-Only - IE11

FROM: P5 - Cross-Site Scripting (XSS) - IE-Only - Older Version (< IE11)

TO: P5 - Cross-Site Scripting (XSS) - IE-Only