### PR TITLE
IDOR category changed to subcategory

### DIFF
--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -1236,7 +1236,7 @@
         {
           "id": "idor",
           "name": "Insecure Direct Object References (IDOR)",
-          "type": "category",
+          "type": "subcategory",
           "children": [
             {
               "id": "read_edit_delete_non_sensitive_information",


### PR DESCRIPTION
We have added category(idor) inside category(broken_access_control) which is incorrect, we can't have category inside a category. IDOR should be subcategory here.