### PR TITLE
deprecated-node-json-fix

### DIFF
--- a/deprecated-node-mapping.json
+++ b/deprecated-node-mapping.json
@@ -206,20 +206,20 @@
   "broken_cryptography.cryptographic_flaw.incorrect_usage": {
     "1.11": "other"
   },
-  "broken_cryptography.use_of_broken_cryptographic_primitive": {
-    "1.11": "cryptographic_weakness.broken_cryptography.use_of_broken_cryptographic_primitive"
-  },
-  "broken_cryptography.use_of_vulnerable_cryptographic_library": {
-    "1.11": "cryptographic_weakness.broken_cryptography.use_of_vulnerable_cryptographic_library"
-  },
-  "cross_site_scripting_xss.ie_only.older_version_ie11": {
+  "cross_site_scripting_xss.ie_only.ie_eleven": {
     "1.11": "other"
+  },
+  "cross_site_scripting_xss.ie_only.older_version_ie_eleven": {
+    "1.11": "cross_site_scripting_xss.ie_only"
   },
   "cross_site_scripting_xss.ie_only.xss_filter_disabled": {
     "1.11": "other"
   },
   "automotive_security_misconfiguration.infotainment_radio_head_unit.pii_leakage": {
     "1.11": "automotive_security_misconfiguration.infotainment_radio_head_unit.sensitive_data_leakage_exposure"
+  },
+  "broken_access_control.server_side_request_forgery_ssrf": {
+    "1.11": "server_security_misconfiguration.server_side_request_forgery_ssrf"
   },
   "broken_access_control.server_side_request_forgery_ssrf.internal_high_impact": {
     "1.11": "server_security_misconfiguration.server_side_request_forgery_ssrf.internal_high_impact"


### PR DESCRIPTION
#### Issue: Resolves #

#### [CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3/cvss_v3.json):

#### [CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe/cwe.json):

#### [Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice/remediation_advice.json):

#### [Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json) (_if needed_):


#### Checklist:

- [ ] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [ ] I have made corresponding changes to the documentation (_if needed_)
