### PR TITLE
Update vulnerability-rating-taxonomy.json

### DIFF
--- a/vulnerability-rating-taxonomy.json
+++ b/vulnerability-rating-taxonomy.json
@@ -836,7 +836,7 @@
               "id": "on_email_change",
               "name": "On Email Change",
               "type": "variant",
-              "priority": 5
+              "priority": 4
             },
             {
               "id": "on_two_fa_activation_change",


### PR DESCRIPTION
On Email Change updated to P4 because it can lead to account takeover - in case if the victim has left his session on a public pc - change of email will lead to Account Takeover

#### Issue: Resolves #

#### [CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3/cvss_v3.json):

#### [CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe/cwe.json):

#### [Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice/remediation_advice.json):

#### [Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json) (_if needed_):


#### Checklist:

- [ ] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [ ] I have made corresponding changes to the documentation (_if needed_)
