### PR TITLE
Fix CVSS for email spoofing due to DMARC misconfiguration

### DIFF
--- a/mappings/cvss_v3/cvss_v3.json
+++ b/mappings/cvss_v3/cvss_v3.json
@@ -103,7 +103,7 @@
             },
             {
               "id": "email_spoofing_to_inbox_due_to_missing_or_misconfigured_dmarc_on_email_domain",
-              "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N"
+              "cvss_v3": "AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:L/A:N"
             }
           ]
         },


### PR DESCRIPTION
Updated the CVSS for the vulnerability related to email spoofing caused by missing or misconfigured DMARC records.

#### Issue: Resolves #

#### [CVSS v3 Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cvss_v3/cvss_v3.json):

#### [CWE Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/cwe/cwe.json):

#### [Remediation Advice Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/mappings/remediation_advice/remediation_advice.json):

#### [Deprecated Node Mapping](https://github.com/bugcrowd/vulnerability-rating-taxonomy/blob/master/deprecated-node-mapping.json) (_if needed_):


#### Checklist:

- [ ] I have added entries to `CHANGELOG.md` and marked it Added/Changed/Removed
- [ ] I have made corresponding changes to the documentation (_if needed_)
